### PR TITLE
Don't leak logback into the dependency tree of things

### DIFF
--- a/mockserver-netty/pom.xml
+++ b/mockserver-netty/pom.xml
@@ -58,6 +58,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>compile</scope>
+            <optional>true</optional> <!-- do not impose on downstream  junit users -->
         </dependency>
 
         <!-- test -->


### PR DESCRIPTION
logback-classic somehow pulls in slf4j-logback, and one winds up with two logging backends, and sadness and confusion. 
