### PR TITLE
#698 fix parsing of charsets from Content-Type header

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/ContentTypeMapper.java
@@ -107,7 +107,7 @@ public class ContentTypeMapper {
     public Charset getCharsetFromContentTypeHeader(String contentType) {
         Charset charset = DEFAULT_HTTP_CHARACTER_SET;
         if (contentType != null) {
-            String charsetName = StringUtils.substringAfterLast(contentType, CHARSET.toString() + (char) HttpConstants.EQUALS).replaceAll("\"", "");
+            String charsetName = StringUtils.substringAfterLast(contentType, CHARSET.toString() + (char) HttpConstants.EQUALS).replaceAll("\"", "").split(";")[0];
             if (isNotBlank(charsetName)) {
                 try {
                     charset = Charset.forName(charsetName);

--- a/mockserver-core/src/test/java/org/mockserver/mappers/ContentTypeMapperTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/ContentTypeMapperTest.java
@@ -171,4 +171,13 @@ public class ContentTypeMapperTest {
         assertThat(charset, is(ContentTypeMapper.DEFAULT_HTTP_CHARACTER_SET));
     }
 
+    @Test
+    public void shouldDetermineCharsetWithAdditonalParameters() {
+        // when
+        Charset charset = new ContentTypeMapper(mockServerLogger).getCharsetFromContentTypeHeader("application/soap+xml;charset=UTF-8;action=\"somerandomstuff\"");
+
+        // then
+        assertThat(charset, is(ContentTypeMapper.DEFAULT_HTTP_CHARACTER_SET));
+    }
+
 }


### PR DESCRIPTION
We ignore the additional parameters now an only take the charset value.