### PR TITLE
fixed request body regex example

### DIFF
--- a/jekyll-www.mock-server.com/mock_server/_includes/request_matcher_code_examples.html
+++ b/jekyll-www.mock-server.com/mock_server/_includes/request_matcher_code_examples.html
@@ -990,7 +990,7 @@ mockServerClient("localhost", 1080).mockAnyResponse({
     "httpRequest": {
         "body": {
             "type": "REGEX",
-            "body": "starts_with_.*"
+            "regex": "starts_with_.*"
         }
     },
     "httpResponse": {


### PR DESCRIPTION
the example for regex body for Rest API is not correct. It should be "regex" not "body"