### PR TITLE
Change parent class to ObjectWithJsonToString

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/serialization/model/VerificationDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/model/VerificationDTO.java
@@ -1,6 +1,6 @@
 package org.mockserver.serialization.model;
 
-import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
+import org.mockserver.model.ObjectWithJsonToString;
 import org.mockserver.verify.Verification;
 
 import static org.mockserver.model.HttpRequest.request;
@@ -10,7 +10,7 @@ import static org.mockserver.verify.VerificationTimes.once;
 /**
  * @author jamesdbloom
  */
-public class VerificationDTO extends ObjectWithReflectiveEqualsHashCodeToString implements DTO<Verification> {
+public class VerificationDTO extends ObjectWithJsonToString implements DTO<Verification> {
     private HttpRequestDTO httpRequest;
     private VerificationTimesDTO times;
 

--- a/mockserver-core/src/main/java/org/mockserver/serialization/model/VerificationTimesDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/model/VerificationTimesDTO.java
@@ -1,12 +1,12 @@
 package org.mockserver.serialization.model;
 
-import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
+import org.mockserver.model.ObjectWithJsonToString;
 import org.mockserver.verify.VerificationTimes;
 
 /**
  * @author jamesdbloom
  */
-public class VerificationTimesDTO extends ObjectWithReflectiveEqualsHashCodeToString implements DTO<VerificationTimes> {
+public class VerificationTimesDTO extends ObjectWithJsonToString implements DTO<VerificationTimes> {
 
     private int atLeast;
     private int atMost;


### PR DESCRIPTION
From the documentation ([verify requests](https://www.mock-server.com/mock_server/mockserver_clients.html#button_client_verify_reqs)) when working with the REST-API you can create an expectation with:

```
curl -v -X PUT "http://localhost:1080/mockserver/verify" -d '{
    "httpRequest": {
        "path": "/simple"
    },
    "times": {
        "atLeast": 2,
        "atMost": 2
    }
}'
```

I am working on a project where I prepare the JSON body using the java model class (`Verification` and `VerificationDTO` in this case).

The issue is that `VerificationDTO#toString()` is not creating the correct JSON body.

Current:
```
VerificationDTO[httpRequest={
  "method" : "POST",
  "path" : "/test"
},times=VerificationTimesDTO[atLeast=1,atMost=1]]
```

Expected:
```
{
  "httpRequest" : {
    "method" : "POST",
    "path" : "/test"
  },
  "times" : {
    "atLeast" : 1,
    "atMost" : 1
  }
}
```

As comparison, when working with `ExpectationDTO#toString()` to create the body of `http://localhost:1080/mockserver/expectation`, it is working as expected.

This PR changes the parent classes of `VerificationDTO` and `VerificationTimesDTO` to solve the issue and to be consistent with other DTO classes such as `ExpectationDTO`, `HttpRequestDTO` or `HttpResponseDTO`.

Work-around: use `Verification` instead of `VerificationDTO` where the `toString()` method is already implemented by the `ObjectWithJsonToString` 



