### PR TITLE
Fixed Max Log Entires for properties in docu html

### DIFF
--- a/jekyll-www.mock-server.com/mock_server/configuration_properties.html
+++ b/jekyll-www.mock-server.com/mock_server/configuration_properties.html
@@ -128,7 +128,7 @@ mockserver.enableCORSForAllResponses=true</code></pre>
     <p>Environment Variable:</p>
     <pre class="code" style="padding: 2px;"><code class="code">MOCKSERVER_MAX_LOG_ENTRIES=...</code></pre>
     <p>Property File:</p>
-    <pre class="code" style="padding: 2px;"><code class="code">mockserver.requesmaxLogEntriestLogSize=...</code></pre>
+    <pre class="code" style="padding: 2px;"><code class="code">mockserver.maxLogEntries=...</code></pre>
     <p>Example:</p>
     <pre class="code" style="padding: 2px;"><code class="code">-Dmockserver.maxLogEntries="2000"</code></pre>
 </div>


### PR DESCRIPTION
I noticed there was a mistake in the HTML documentation regarding the property maxLogEntries.