### PR TITLE
Adding support for global server state between requests, session.

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/matchers/HttpRequestMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/matchers/HttpRequestMatcher.java
@@ -45,6 +45,7 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
     private static final String HEADERS = "headers";
     private static final String BODY = "body";
     private static final String PATH = "path";
+    private static final String SESSION = "session";
     private static final String METHOD = "method";
     private static final String COMMA = ",";
     private static final String EMPTY = "";
@@ -60,6 +61,7 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
     private BooleanMatcher keepAliveMatcher = null;
     private BodyDTO bodyDTOMatcher = null;
     private BooleanMatcher sslMatcher = null;
+    private HashMapMatcher sessionMatcher = null;
     private boolean controlPlaneMatcher;
     private boolean responseInProgress = false;
     private ObjectMapper objectMapper = ObjectMapperFactory.createObjectMapper();
@@ -84,6 +86,7 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
                 withCookies(httpRequest.getCookies());
                 withKeepAlive(httpRequest.isKeepAlive());
                 withSsl(httpRequest.isSecure());
+                withSession(httpRequest.getSession());
             }
             return true;
         }
@@ -131,7 +134,7 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
     private void withPath(NottableString path) {
         this.pathMatcher = new RegexStringMatcher(mockServerLogger, path, controlPlaneMatcher);
     }
-
+  
     private void withQueryStringParameters(Parameters parameters) {
         this.queryStringParameterMatcher = new MultiValueMapMatcher(mockServerLogger, parameters, controlPlaneMatcher);
     }
@@ -208,6 +211,10 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
     private void withCookies(Cookies cookies) {
         this.cookieMatcher = new HashMapMatcher(mockServerLogger, cookies, controlPlaneMatcher);
     }
+        
+    private void withSession(Session session) {
+        this.sessionMatcher = new HashMapMatcher(mockServerLogger, session, controlPlaneMatcher);
+    }
 
     private void withKeepAlive(Boolean keepAlive) {
         this.keepAliveMatcher = new BooleanMatcher(mockServerLogger, keepAlive);
@@ -275,7 +282,7 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
                     if (failFast(pathMatcher, matchDifference, becauseBuilder, pathMatches, PATH, EMPTY)) {
                         return false;
                     }
-
+                   
                     boolean bodyMatches = bodyMatches(matchDifference, request);
                     if (failFast(bodyMatcher, matchDifference, becauseBuilder, bodyMatches, BODY, EMPTY)) {
                         return false;
@@ -288,6 +295,11 @@ public class HttpRequestMatcher extends NotMatcher<HttpRequest> {
 
                     boolean cookiesMatch = matches(COOKIES, matchDifference, cookieMatcher, request.getCookies());
                     if (failFast(cookieMatcher, matchDifference, becauseBuilder, cookiesMatch, COOKIES, EMPTY)) {
+                        return false;
+                    }
+                    
+                    boolean sessionMatches = matches(SESSION, matchDifference, sessionMatcher, request.getSession());
+                    if (failFast(sessionMatcher, matchDifference, becauseBuilder, sessionMatches, SESSION, EMPTY)) {
                         return false;
                     }
 

--- a/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
@@ -11,6 +11,8 @@ import org.mockserver.metrics.Metrics;
 import org.mockserver.model.Action;
 import org.mockserver.model.HttpObjectCallback;
 import org.mockserver.model.HttpRequest;
+import org.mockserver.model.Session;
+import org.mockserver.model.SessionEntry;
 import org.mockserver.scheduler.Scheduler;
 import org.mockserver.ui.MockServerMatcherNotifier;
 import org.slf4j.event.Level;
@@ -28,13 +30,14 @@ import static org.mockserver.metrics.Metrics.Name.*;
  * @author jamesdbloom
  */
 public class MockServerMatcher extends MockServerMatcherNotifier {
-
+    
     final CircularPriorityQueue<String, HttpRequestMatcher> httpRequestMatchers = new CircularPriorityQueue<>(
         maxExpectations(),
         HttpRequestMatcher.class,
         EXPECTATION_PRIORITY_COMPARATOR,
         httpRequestMatcher -> httpRequestMatcher.getExpectation().getId()
     );
+    private final Session mockServerSession = new Session();
     private final MockServerLogger mockServerLogger;
     private WebSocketClientRegistry webSocketClientRegistry;
     private MatcherBuilder matcherBuilder;
@@ -141,6 +144,9 @@ public class MockServerMatcher extends MockServerMatcherNotifier {
 
     public void reset(Cause cause) {
         new ArrayList<>(httpRequestMatchers).forEach(httpRequestMatcher -> removeHttpRequestMatcher(httpRequestMatcher, cause, false));
+        synchronized (mockServerSession) {
+            mockServerSession.getMap().clear();    
+        }
         Metrics.clearActionMetrics();
         notifyListeners(this, cause);
     }
@@ -151,11 +157,13 @@ public class MockServerMatcher extends MockServerMatcherNotifier {
 
     public Expectation firstMatchingExpectation(HttpRequest httpRequest) {
         Expectation matchingExpectation = null;
+        httpRequest = readFromSession(httpRequest);
         for (HttpRequestMatcher httpRequestMatcher : httpRequestMatchers.toSortedList()) {
             boolean remainingMatchesDecremented = false;
             if (httpRequestMatcher.matches(new MatchDifference(httpRequest), httpRequest)) {
                 matchingExpectation = httpRequestMatcher.getExpectation();
                 httpRequestMatcher.setResponseInProgress(true);
+                writeToSession(matchingExpectation);
                 if (matchingExpectation.decrementRemainingMatches()) {
                     remainingMatchesDecremented = true;
                 }
@@ -205,6 +213,34 @@ public class MockServerMatcher extends MockServerMatcherNotifier {
             }
         }
         return expectation;
+    }
+    
+    private HttpRequest readFromSession(HttpRequest request) {
+        synchronized (mockServerSession) {
+            if (mockServerSession.isEmpty()) {
+                return request;
+            }
+            return request.clone().withSession(mockServerSession.clone());         
+        }
+    }
+    
+    private void writeToSession(Expectation matchedExpectation) {
+        if (matchedExpectation == null || matchedExpectation.getHttpResponse() == null) {
+            return;
+        }
+        Session sessionEntries = matchedExpectation.getHttpResponse().getSession();
+        if (sessionEntries == null) {
+            return;
+        }
+        synchronized (mockServerSession) {
+            if (sessionEntries.isEmpty()) { //if response had explicit empty session map it tells us to clear all entries
+                mockServerSession.getMap().clear();
+            } else {
+                for (SessionEntry e : sessionEntries.getEntries()) { //else - merge the response with the existing session map
+                    mockServerSession.withEntry(e);
+                }
+            }
+        }
     }
 
     private void removeHttpRequestMatcher(HttpRequestMatcher httpRequestMatcher) {

--- a/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
@@ -221,8 +221,11 @@ public class MockServerMatcher extends MockServerMatcherNotifier {
     }
     
     private HttpRequest readFromSession(HttpRequest request) {
+        if (request == null) {
+            return null;
+        }
         synchronized (mockServerSession) {
-            if (mockServerSession.isEmpty() && (request.getSession() == null || request.getSession().isEmpty()) ) {
+            if (mockServerSession.isEmpty() && (request.getSession() == null || request.getSession().isEmpty())) {
                 return request;
             }
             return request.clone().withSession(mockServerSession.clone());         

--- a/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
@@ -217,7 +217,7 @@ public class MockServerMatcher extends MockServerMatcherNotifier {
     
     private HttpRequest readFromSession(HttpRequest request) {
         synchronized (mockServerSession) {
-            if (mockServerSession.isEmpty()) {
+            if (mockServerSession.isEmpty() && (request.getSession() == null || request.getSession().isEmpty()) ) {
                 return request;
             }
             return request.clone().withSession(mockServerSession.clone());         

--- a/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/MockServerMatcher.java
@@ -37,16 +37,21 @@ public class MockServerMatcher extends MockServerMatcherNotifier {
         EXPECTATION_PRIORITY_COMPARATOR,
         httpRequestMatcher -> httpRequestMatcher.getExpectation().getId()
     );
-    private final Session mockServerSession = new Session();
+    private final Session mockServerSession;
     private final MockServerLogger mockServerLogger;
     private WebSocketClientRegistry webSocketClientRegistry;
     private MatcherBuilder matcherBuilder;
 
     public MockServerMatcher(MockServerLogger mockServerLogger, Scheduler scheduler, WebSocketClientRegistry webSocketClientRegistry) {
+        this(mockServerLogger, scheduler, webSocketClientRegistry, new Session());
+    }
+    
+    public MockServerMatcher(MockServerLogger mockServerLogger, Scheduler scheduler, WebSocketClientRegistry webSocketClientRegistry, Session mockServerSession) {
         super(scheduler);
         this.matcherBuilder = new MatcherBuilder(mockServerLogger);
         this.mockServerLogger = mockServerLogger;
         this.webSocketClientRegistry = webSocketClientRegistry;
+        this.mockServerSession = mockServerSession;
     }
 
     public void add(Expectation expectation, Cause cause) {

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
@@ -30,6 +30,7 @@ public class HttpRequest extends Not implements HttpObject<HttpRequest, Body> {
     private Boolean keepAlive = null;
     private Boolean secure = null;
     private SocketAddress socketAddress;
+    private Session session;
 
     public static HttpRequest request() {
         return new HttpRequest();
@@ -689,6 +690,15 @@ public class HttpRequest extends Not implements HttpObject<HttpRequest, Body> {
             throw new IllegalArgumentException("Host header must be provided to determine remote socket address, the request does not include the \"Host\" header:" + NEW_LINE + this);
         }
     }
+    
+    public Session getSession() {
+        return session;
+    }
+    
+    public HttpRequest withSession(Session session) {
+        this.session = session;
+        return this;
+    }
 
     @SuppressWarnings("MethodDoesntCallSuperMethod")
     public HttpRequest clone() {
@@ -701,7 +711,8 @@ public class HttpRequest extends Not implements HttpObject<HttpRequest, Body> {
             .withCookies(cookies != null ? cookies.clone() : null)
             .withKeepAlive(keepAlive)
             .withSecure(secure)
-            .withSocketAddress(socketAddress);
+            .withSocketAddress(socketAddress)
+            .withSession(session);
     }
 
     public HttpRequest update(HttpRequest replaceRequest) {
@@ -732,6 +743,10 @@ public class HttpRequest extends Not implements HttpObject<HttpRequest, Body> {
         if (replaceRequest.getSocketAddress() != null) {
             withSocketAddress(replaceRequest.getSocketAddress());
         }
+        if (replaceRequest.getSession() != null) {
+            withSession(replaceRequest.getSession());
+        }
+
         return this;
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpResponse.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpResponse.java
@@ -26,6 +26,7 @@ public class HttpResponse extends Action<HttpResponse> implements HttpObject<Htt
     private Headers headers;
     private Cookies cookies;
     private ConnectionOptions connectionOptions;
+    private Session session;
 
     /**
      * Static builder to create a response.
@@ -487,6 +488,15 @@ public class HttpResponse extends Action<HttpResponse> implements HttpObject<Htt
         return connectionOptions;
     }
 
+    public Session getSession() {
+        return session;
+    }
+
+    public HttpResponse withSession(Session session) {
+        this.session = session;
+        return this;
+    }
+
     @Override
     @JsonIgnore
     public Type getType() {
@@ -502,7 +512,8 @@ public class HttpResponse extends Action<HttpResponse> implements HttpObject<Htt
             .withHeaders(headers != null ? headers.clone() : null)
             .withCookies(cookies != null ? cookies.clone() : null)
             .withDelay(getDelay())
-            .withConnectionOptions(connectionOptions);
+            .withConnectionOptions(connectionOptions)
+            .withSession(session);
     }
 
     public HttpResponse update(HttpResponse replaceResponse) {
@@ -523,6 +534,9 @@ public class HttpResponse extends Action<HttpResponse> implements HttpObject<Htt
         }
         if (replaceResponse.getConnectionOptions() != null) {
             withConnectionOptions(replaceResponse.getConnectionOptions());
+        }
+        if (replaceResponse.getSession() != null) {
+            withSession(replaceResponse.getSession());
         }
         return this;
     }

--- a/mockserver-core/src/main/java/org/mockserver/model/KeysAndValues.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/KeysAndValues.java
@@ -13,7 +13,7 @@ import static org.mockserver.model.NottableString.string;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class KeysAndValues<T extends KeyAndValue, K extends KeysAndValues> extends ObjectWithJsonToString {
 
-    private final Map<NottableString, NottableString> map = new LinkedHashMap<>();
+    private final Map<NottableString, NottableString> map = Collections.synchronizedMap(new LinkedHashMap<>());
 
     public CaseInsensitiveRegexHashMap toCaseInsensitiveRegexMultiMap(MockServerLogger mockServerLogger, List<T> entries, boolean controlPlaneMatcher) {
         CaseInsensitiveRegexHashMap caseInsensitiveRegexHashMap = new CaseInsensitiveRegexHashMap(mockServerLogger, controlPlaneMatcher);
@@ -27,25 +27,25 @@ public abstract class KeysAndValues<T extends KeyAndValue, K extends KeysAndValu
 
     public abstract T build(NottableString name, NottableString value);
 
-    public K withEntries(List<T> cookies) {
+    public K withEntries(List<T> entries) {
         map.clear();
-        if (cookies != null) {
-            for (T cookie : cookies) {
-                withEntry(cookie);
+        if (entries != null) {
+            for (T entry : entries) {
+                withEntry(entry);
             }
         }
         return (K) this;
     }
 
-    public K withEntries(T... cookies) {
-        if (cookies != null) {
-            withEntries(Arrays.asList(cookies));
+    public K withEntries(T... entries) {
+        if (entries != null) {
+            withEntries(Arrays.asList(entries));
         }
         return (K) this;
     }
 
-    public K withEntry(T cookie) {
-        map.put(cookie.getName(), cookie.getValue());
+    public K withEntry(T entry) {
+        map.put(entry.getName(), entry.getValue());
         return (K) this;
     }
 
@@ -61,11 +61,11 @@ public abstract class KeysAndValues<T extends KeyAndValue, K extends KeysAndValu
 
     public List<T> getEntries() {
         if (!map.isEmpty()) {
-            ArrayList<T> cookies = new ArrayList<>();
+            ArrayList<T> entries = new ArrayList<>();
             for (NottableString nottableString : map.keySet()) {
-                cookies.add(build(nottableString, map.get(nottableString)));
+                entries.add(build(nottableString, map.get(nottableString)));
             }
-            return cookies;
+            return entries;
         } else {
             return Collections.emptyList();
         }

--- a/mockserver-core/src/main/java/org/mockserver/model/Session.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/Session.java
@@ -1,0 +1,24 @@
+package org.mockserver.model;
+
+import java.util.List;
+
+public class Session extends KeysAndValues<SessionEntry, Session> {
+
+    public Session(List<SessionEntry> entries) {
+        withEntries(entries);
+    }
+
+    public Session(SessionEntry... entries) {
+        withEntries(entries);
+    }
+
+    @Override
+    public SessionEntry build(NottableString name, NottableString value) {
+        return new SessionEntry(name, value);
+    }
+
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    public Session clone() {
+        return new Session().withEntries(getEntries());
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/model/SessionEntry.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/SessionEntry.java
@@ -1,0 +1,21 @@
+package org.mockserver.model;
+
+
+public class SessionEntry extends KeyAndValue {
+
+    public SessionEntry(String name, String value) {
+        super(name, value);
+    }
+
+    public SessionEntry(NottableString name, NottableString value) {
+        super(name, value);
+    }
+
+    public static SessionEntry sessionEntry(String name, String value) {
+        return new SessionEntry(name, value);
+    }
+
+    public static SessionEntry sessionEntry(NottableString name, NottableString value) {
+        return new SessionEntry(name, value);
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/serialization/ObjectMapperFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/ObjectMapperFactory.java
@@ -9,6 +9,7 @@ import org.mockserver.serialization.deserializers.body.BodyWithContentTypeDTODes
 import org.mockserver.serialization.deserializers.collections.CookiesDeserializer;
 import org.mockserver.serialization.deserializers.collections.HeadersDeserializer;
 import org.mockserver.serialization.deserializers.collections.ParametersDeserializer;
+import org.mockserver.serialization.deserializers.collections.SessionDeserializer;
 import org.mockserver.serialization.deserializers.condition.TimeToLiveDTODeserializer;
 import org.mockserver.serialization.deserializers.condition.VerificationTimesDTODeserializer;
 import org.mockserver.serialization.deserializers.string.NottableStringDeserializer;
@@ -16,6 +17,7 @@ import org.mockserver.serialization.serializers.body.*;
 import org.mockserver.serialization.serializers.collections.CookiesSerializer;
 import org.mockserver.serialization.serializers.collections.HeadersSerializer;
 import org.mockserver.serialization.serializers.collections.ParametersSerializer;
+import org.mockserver.serialization.serializers.collections.SessionSerializer;
 import org.mockserver.serialization.serializers.condition.VerificationTimesDTOSerializer;
 import org.mockserver.serialization.serializers.condition.VerificationTimesSerializer;
 import org.mockserver.serialization.serializers.request.HttpRequestDTOSerializer;
@@ -106,7 +108,8 @@ public class ObjectMapperFactory {
             // key and multivalue
             new HeadersDeserializer(),
             new ParametersDeserializer(),
-            new CookiesDeserializer()
+            new CookiesDeserializer(),
+            new SessionDeserializer()
         );
         for (JsonDeserializer jsonDeserializer : jsonDeserializers) {
             Class type = jsonDeserializer.handledType();
@@ -158,6 +161,7 @@ public class ObjectMapperFactory {
             new HeadersSerializer(),
             new ParametersSerializer(),
             new CookiesSerializer(),
+            new SessionSerializer(),
             // log
             new org.mockserver.serialization.serializers.log.LogEntrySerializer()
         );

--- a/mockserver-core/src/main/java/org/mockserver/serialization/deserializers/collections/CookiesDeserializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/deserializers/collections/CookiesDeserializer.java
@@ -1,88 +1,21 @@
 package org.mockserver.serialization.deserializers.collections;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.JsonTokenId;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.mockserver.model.Cookies;
-import org.mockserver.model.NottableString;
-
-import java.io.IOException;
-
-import static org.mockserver.model.NottableString.string;
 
 /**
  * @author jamesdbloom
  */
-public class CookiesDeserializer extends StdDeserializer<Cookies> {
+public class CookiesDeserializer extends KeysAndValuesDeserializer<Cookies> {
+
+    private static final long serialVersionUID = 1L;
 
     public CookiesDeserializer() {
         super(Cookies.class);
     }
-
+    
     @Override
-    public Cookies deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        if (p.isExpectedStartArrayToken()) {
-            return deserializeArray(p, ctxt, ctxt.getNodeFactory());
-        } else if (p.isExpectedStartObjectToken()) {
-            return deserializeObject(p, ctxt, ctxt.getNodeFactory());
-        } else {
-            return (Cookies) ctxt.handleUnexpectedToken(Cookies.class, p);
-        }
+    protected Cookies createObject() {
+        return new Cookies();
     }
 
-    private Cookies deserializeObject(JsonParser jsonParser, DeserializationContext ctxt, JsonNodeFactory nodeFactory) throws IOException {
-        Cookies cookies = new Cookies();
-        NottableString key = string("");
-        while (true) {
-            JsonToken t = jsonParser.nextToken();
-            switch (t.id()) {
-                case JsonTokenId.ID_FIELD_NAME:
-                    key = string(jsonParser.getText());
-                    break;
-                case JsonTokenId.ID_STRING:
-                    cookies.withEntry(key, string(ctxt.readValue(jsonParser, String.class)));
-                    break;
-                case JsonTokenId.ID_END_OBJECT:
-                    return cookies;
-                default:
-                    throw new RuntimeException("Unexpected token: \"" + t + "\" id: \"" + t.id() + "\" text: \"" + jsonParser.getText());
-            }
-        }
-    }
-
-    private Cookies deserializeArray(JsonParser jsonParser, DeserializationContext ctxt, JsonNodeFactory nodeFactory) throws IOException {
-        Cookies headers = new Cookies();
-        NottableString key = null;
-        NottableString value = null;
-        String fieldName = null;
-        while (true) {
-            JsonToken t = jsonParser.nextToken();
-            switch (t.id()) {
-                case JsonTokenId.ID_END_ARRAY:
-                    return headers;
-                case JsonTokenId.ID_START_OBJECT:
-                    key = null;
-                    value = null;
-                    break;
-                case JsonTokenId.ID_FIELD_NAME:
-                    fieldName = jsonParser.getText();
-                    break;
-                case JsonTokenId.ID_STRING:
-                    if ("name".equals(fieldName)) {
-                        key = string(ctxt.readValue(jsonParser, String.class));
-                    } else if ("value".equals(fieldName)) {
-                        value = string(ctxt.readValue(jsonParser, String.class));
-                    }
-                    break;
-                case JsonTokenId.ID_END_OBJECT:
-                    headers.withEntry(key, value);
-                    break;
-                default:
-                    throw new RuntimeException("Unexpected token: \"" + t + "\" id: \"" + t.id() + "\" text: \"" + jsonParser.getText());
-            }
-        }
-    }
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/deserializers/collections/KeysAndValuesDeserializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/deserializers/collections/KeysAndValuesDeserializer.java
@@ -1,0 +1,98 @@
+package org.mockserver.serialization.deserializers.collections;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import org.mockserver.model.KeyAndValue;
+import org.mockserver.model.KeysAndValues;
+import org.mockserver.model.NottableString;
+
+import java.io.IOException;
+
+import static org.mockserver.model.NottableString.string;
+
+/**
+ * @author jamesdbloom
+ */
+public abstract class KeysAndValuesDeserializer<KV extends KeysAndValues<? extends KeyAndValue, ?>> extends StdDeserializer<KV> {
+    private static final long serialVersionUID = 1L;
+    
+    private Class<KV> type;
+    
+    public KeysAndValuesDeserializer(Class<KV> clazz) {
+        super(clazz);
+        this.type = clazz;
+    }
+    
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public KV deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        if (p.isExpectedStartArrayToken()) {
+            return deserializeArray(p, ctxt, ctxt.getNodeFactory());
+        } else if (p.isExpectedStartObjectToken()) {
+            return deserializeObject(p, ctxt, ctxt.getNodeFactory());
+        } else {
+            return (KV) ctxt.handleUnexpectedToken(type, p);
+        }
+    }
+    
+    protected abstract KV createObject();
+
+    private KV deserializeObject(JsonParser jsonParser, DeserializationContext ctxt, JsonNodeFactory nodeFactory) throws IOException {
+        KV kv = createObject();
+        NottableString key = string("");
+        while (true) {
+            JsonToken t = jsonParser.nextToken();
+            switch (t.id()) {
+                case JsonTokenId.ID_FIELD_NAME:
+                    key = string(jsonParser.getText());
+                    break;
+                case JsonTokenId.ID_STRING:
+                    kv.withEntry(key, string(ctxt.readValue(jsonParser, String.class)));
+                    break;
+                case JsonTokenId.ID_END_OBJECT:
+                    return kv;
+                default:
+                    throw new RuntimeException("Unexpected token: \"" + t + "\" id: \"" + t.id() + "\" text: \"" + jsonParser.getText());
+            }
+        }
+    }
+
+    private KV deserializeArray(JsonParser jsonParser, DeserializationContext ctxt, JsonNodeFactory nodeFactory) throws IOException {
+        KV headers = createObject();
+        NottableString key = null;
+        NottableString value = null;
+        String fieldName = null;
+        while (true) {
+            JsonToken t = jsonParser.nextToken();
+            switch (t.id()) {
+                case JsonTokenId.ID_END_ARRAY:
+                    return headers;
+                case JsonTokenId.ID_START_OBJECT:
+                    key = null;
+                    value = null;
+                    break;
+                case JsonTokenId.ID_FIELD_NAME:
+                    fieldName = jsonParser.getText();
+                    break;
+                case JsonTokenId.ID_STRING:
+                    if ("name".equals(fieldName)) {
+                        key = string(ctxt.readValue(jsonParser, String.class));
+                    } else if ("value".equals(fieldName)) {
+                        value = string(ctxt.readValue(jsonParser, String.class));
+                    }
+                    break;
+                case JsonTokenId.ID_END_OBJECT:
+                    headers.withEntry(key, value);
+                    break;
+                default:
+                    throw new RuntimeException("Unexpected token: \"" + t + "\" id: \"" + t.id() + "\" text: \"" + jsonParser.getText());
+            }
+        }
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/serialization/deserializers/collections/SessionDeserializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/deserializers/collections/SessionDeserializer.java
@@ -1,0 +1,18 @@
+package org.mockserver.serialization.deserializers.collections;
+
+import org.mockserver.model.Session;
+
+public class SessionDeserializer extends KeysAndValuesDeserializer<Session> {
+
+    private static final long serialVersionUID = 1L;
+
+    public SessionDeserializer() {
+        super(Session.class);
+    }
+    
+    @Override
+    protected Session createObject() {
+        return new Session();
+    }
+
+}

--- a/mockserver-core/src/main/java/org/mockserver/serialization/model/HttpRequestDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/model/HttpRequestDTO.java
@@ -17,6 +17,7 @@ public class HttpRequestDTO extends NotDTO implements DTO<HttpRequest> {
     private Boolean keepAlive = null;
     private Boolean secure = null;
     private SocketAddressDTO socketAddress = null;
+    private Session session;
 
     public HttpRequestDTO(HttpRequest httpRequest) {
         this(httpRequest, false);
@@ -40,6 +41,7 @@ public class HttpRequestDTO extends NotDTO implements DTO<HttpRequest> {
             if (httpRequest.getSocketAddress() != null) {
                 socketAddress = new SocketAddressDTO(httpRequest.getSocketAddress());
             }
+            session = httpRequest.getSession();
         }
     }
 
@@ -53,7 +55,8 @@ public class HttpRequestDTO extends NotDTO implements DTO<HttpRequest> {
             .withCookies(cookies)
             .withSecure(secure)
             .withKeepAlive(keepAlive)
-            .withSocketAddress(socketAddress != null ? socketAddress.buildObject() : null);
+            .withSocketAddress(socketAddress != null ? socketAddress.buildObject() : null)
+            .withSession(session);
     }
 
     public NottableString getMethod() {
@@ -134,6 +137,15 @@ public class HttpRequestDTO extends NotDTO implements DTO<HttpRequest> {
 
     public HttpRequestDTO setSocketAddress(SocketAddressDTO socketAddress) {
         this.socketAddress = socketAddress;
+        return this;
+    }
+    
+    public Session getSession() {
+        return session;
+    }
+    
+    public HttpRequestDTO setSession(Session session) {
+        this.session = session;
         return this;
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/model/HttpResponseDTO.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/model/HttpResponseDTO.java
@@ -4,6 +4,7 @@ import org.mockserver.model.Cookies;
 import org.mockserver.model.Headers;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.ObjectWithReflectiveEqualsHashCodeToString;
+import org.mockserver.model.Session;
 
 /**
  * @author jamesdbloom
@@ -16,6 +17,8 @@ public class HttpResponseDTO extends ObjectWithReflectiveEqualsHashCodeToString 
     private Headers headers;
     private DelayDTO delay;
     private ConnectionOptionsDTO connectionOptions;
+    private Session session;
+    
 
     public HttpResponseDTO() {
     }
@@ -29,6 +32,7 @@ public class HttpResponseDTO extends ObjectWithReflectiveEqualsHashCodeToString 
             cookies = httpResponse.getCookies();
             delay = (httpResponse.getDelay() != null ? new DelayDTO(httpResponse.getDelay()) : null);
             connectionOptions = (httpResponse.getConnectionOptions() != null ? new ConnectionOptionsDTO(httpResponse.getConnectionOptions()) : null);
+            session = httpResponse.getSession();
         }
     }
 
@@ -40,7 +44,8 @@ public class HttpResponseDTO extends ObjectWithReflectiveEqualsHashCodeToString 
             .withHeaders(headers)
             .withCookies(cookies)
             .withDelay((delay != null ? delay.buildObject() : null))
-            .withConnectionOptions((connectionOptions != null ? connectionOptions.buildObject() : null));
+            .withConnectionOptions((connectionOptions != null ? connectionOptions.buildObject() : null))
+            .withSession(session);
     }
 
     public Integer getStatusCode() {
@@ -103,6 +108,15 @@ public class HttpResponseDTO extends ObjectWithReflectiveEqualsHashCodeToString 
 
     public HttpResponseDTO setConnectionOptions(ConnectionOptionsDTO connectionOptions) {
         this.connectionOptions = connectionOptions;
+        return this;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public HttpResponseDTO setSession(Session session) {
+        this.session = session;
         return this;
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/collections/CookiesSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/collections/CookiesSerializer.java
@@ -1,31 +1,18 @@
 package org.mockserver.serialization.serializers.collections;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import org.mockserver.model.Cookie;
+
 import org.mockserver.model.Cookies;
-
-import java.io.IOException;
-
-import static org.mockserver.model.NottableString.serialiseNottableString;
 
 /**
  * @author jamesdbloom
  */
-public class CookiesSerializer extends StdSerializer<Cookies> {
+public class CookiesSerializer extends KeysAndValuesSerializer<Cookies> {
+
+    private static final long serialVersionUID = 1L;
 
     public CookiesSerializer() {
         super(Cookies.class);
     }
-
-    @Override
-    public void serialize(Cookies collection, JsonGenerator jgen, SerializerProvider provider) throws IOException {
-        jgen.writeStartObject();
-        for (Cookie cookie : collection.getEntries()) {
-            jgen.writeStringField(serialiseNottableString(cookie.getName()), serialiseNottableString(cookie.getValue()));
-        }
-        jgen.writeEndObject();
-    }
+   
 
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/collections/KeysAndValuesSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/collections/KeysAndValuesSerializer.java
@@ -1,0 +1,33 @@
+package org.mockserver.serialization.serializers.collections;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.mockserver.model.KeyAndValue;
+import org.mockserver.model.KeysAndValues;
+
+import java.io.IOException;
+
+import static org.mockserver.model.NottableString.serialiseNottableString;
+
+/**
+ * @author jamesdbloom
+ */
+public class KeysAndValuesSerializer<KV extends KeysAndValues<? extends KeyAndValue, ?>> extends StdSerializer<KV> {
+
+    private static final long serialVersionUID = 1L;
+
+    public KeysAndValuesSerializer(Class<KV> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public void serialize(KV collection, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        jgen.writeStartObject();
+        for (KeyAndValue cookie : collection.getEntries()) {
+            jgen.writeStringField(serialiseNottableString(cookie.getName()), serialiseNottableString(cookie.getValue()));
+        }
+        jgen.writeEndObject();
+    }
+
+}

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/collections/SessionSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/collections/SessionSerializer.java
@@ -1,0 +1,15 @@
+package org.mockserver.serialization.serializers.collections;
+
+
+import org.mockserver.model.Session;
+
+public class SessionSerializer extends KeysAndValuesSerializer<Session> {
+
+    private static final long serialVersionUID = 1L;
+
+    public SessionSerializer() {
+        super(Session.class);
+    }
+   
+
+}

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/request/HttpRequestDTOSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/request/HttpRequestDTOSerializer.java
@@ -51,6 +51,9 @@ public class HttpRequestDTOSerializer extends StdSerializer<HttpRequestDTO> {
         if (httpRequest.getBody() != null) {
             jgen.writeObjectField("body", httpRequest.getBody());
         }
+        if (httpRequest.getSession() != null && !httpRequest.getSession().isEmpty()) {
+            jgen.writeObjectField("session", httpRequest.getSession());
+        }
         jgen.writeEndObject();
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/request/HttpRequestSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/request/HttpRequestSerializer.java
@@ -51,6 +51,9 @@ public class HttpRequestSerializer extends StdSerializer<HttpRequest> {
         if (httpRequest.getBody() != null && isNotBlank(String.valueOf(httpRequest.getBody().getValue()))) {
             jgen.writeObjectField("body", httpRequest.getBody());
         }
+        if (httpRequest.getSession() != null && !httpRequest.getSession().isEmpty()) {
+            jgen.writeObjectField("session", httpRequest.getSession());
+        }
         jgen.writeEndObject();
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializer.java
@@ -51,6 +51,9 @@ public class HttpResponseDTOSerializer extends StdSerializer<HttpResponseDTO> {
         if (httpResponseDTO.getConnectionOptions() != null) {
             jgen.writeObjectField("connectionOptions", httpResponseDTO.getConnectionOptions());
         }
+        if (httpResponseDTO.getSession() != null) {
+            jgen.writeObjectField("session", httpResponseDTO.getSession());
+        }
         jgen.writeEndObject();
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseSerializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseSerializer.java
@@ -53,6 +53,9 @@ public class HttpResponseSerializer extends StdSerializer<HttpResponse> {
         if (httpResponse.getConnectionOptions() != null) {
             jgen.writeObjectField("connectionOptions", httpResponse.getConnectionOptions());
         }
+        if (httpResponse.getSession() != null) {
+            jgen.writeObjectField("session", httpResponse.getSession());
+        }
         jgen.writeEndObject();
     }
 }

--- a/mockserver-core/src/main/resources/org/mockserver/model/schema/httpRequest.json
+++ b/mockserver-core/src/main/resources/org/mockserver/model/schema/httpRequest.json
@@ -29,6 +29,9 @@
         },
         "socketAddress": {
             "$ref": "#/definitions/socketAddress"
+        },
+        "session": {
+            "$ref": "#/definitions/keyToValue"
         }
     },
     "definitions": {

--- a/mockserver-core/src/main/resources/org/mockserver/model/schema/httpResponse.json
+++ b/mockserver-core/src/main/resources/org/mockserver/model/schema/httpResponse.json
@@ -23,6 +23,9 @@
         },
         "reasonPhrase": {
             "type": "string"
+        },
+        "session": {
+            "$ref": "#/definitions/keyToValue"
         }
     },
     "definitions": {

--- a/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestMatcherLogTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestMatcherLogTest.java
@@ -324,6 +324,7 @@ public class HttpRequestMatcherLogTest {
                     "  " + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +
                     "  query matched" + NEW_LINE +
                     "  keep-alive didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
@@ -451,6 +452,7 @@ public class HttpRequestMatcherLogTest {
                     "  " + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
@@ -516,6 +518,7 @@ public class HttpRequestMatcherLogTest {
                 "  body matched" + NEW_LINE +
                 "  headers matched" + NEW_LINE +
                 "  cookies matched" + NEW_LINE +
+                "  session matched" + NEW_LINE +
                 "  query matched" + NEW_LINE +
                 "  keep-alive didn't match: " + NEW_LINE +
                 "  " + NEW_LINE +
@@ -546,6 +549,7 @@ public class HttpRequestMatcherLogTest {
                 "  body matched" + NEW_LINE +
                 "  headers matched" + NEW_LINE +
                 "  cookies matched" + NEW_LINE +
+                "  session matched" + NEW_LINE +
                 "  query matched" + NEW_LINE +
                 "  keep-alive didn't match: " + NEW_LINE +
                 "  " + NEW_LINE +
@@ -601,6 +605,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
@@ -632,6 +637,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
@@ -701,6 +707,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
@@ -742,6 +749,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
@@ -800,6 +808,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive matched" + NEW_LINE +
                     "  sslMatches didn't match: " + NEW_LINE +
@@ -831,6 +840,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query matched" + NEW_LINE +
                     "  keep-alive matched" + NEW_LINE +
                     "  sslMatches didn't match: " + NEW_LINE +
@@ -1145,6 +1155,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
                     "    multimap subset match failed expected:" + NEW_LINE +
@@ -1212,6 +1223,7 @@ public class HttpRequestMatcherLogTest {
                     "  body matched" + NEW_LINE +
                     "  headers matched" + NEW_LINE +
                     "  cookies matched" + NEW_LINE +
+                    "  session matched" + NEW_LINE +                    
                     "  query didn't match: " + NEW_LINE +
                     "  " + NEW_LINE +
                     "    multimap subset match failed expected:" + NEW_LINE +

--- a/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestMatcherTest.java
@@ -1067,6 +1067,59 @@ public class HttpRequestMatcherTest {
     public void doesNotMatchIncorrectCookieValueRegex() {
         assertFalse(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withCookies(new Cookie("name", "[A-Z]{0,10}"))).matches(null, new HttpRequest().withCookies(new Cookie("name", "value1"))));
     }
+    
+    @Test
+    public void matchesMatchingSession() {
+        assertTrue(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(new Session().withEntry("key1", "value1"))).matches(null, new HttpRequest().withSession(new Session().withEntry("key1", "value1"))));
+    }
+    
+    @Test
+    public void matchesMatchingSessionWithRegex() {
+        assertTrue(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(new Session().withEntry("key1", "value[0-9]+"))).matches(null, new HttpRequest().withSession(new Session().withEntry("key1", "value1"))));
+    }
+    
+    
+
+    @Test
+    public void doesNotMatchIncorrectSessionEntryName() {
+        assertFalse(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(new Session().withEntry("key1", "value1"))).matches(null, new HttpRequest().withSession(new Session().withEntry("key2", "value2"))));
+    }
+    
+    @Test
+    public void matchesMatchingSessionWithMultipleEntries() {
+        assertTrue(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(
+                new Session()
+                .withEntry("key1", "value1")
+                .withEntry("key2", "value2"))).matches(
+            null, new HttpRequest().withSession(
+                new Session()
+                .withEntry("key2", "value2")
+                .withEntry("key1", "value1")))
+        );
+    }
+    
+    @Test
+    public void doesNotMatchMissingSessionEntry() {
+        assertFalse(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(
+                new Session()
+                .withEntry("key1", "value1")
+                .withEntry("key2", "value2"))).matches(
+            null, new HttpRequest().withSession(
+                new Session()
+                .withEntry("key2", "value2")))
+        );
+    }
+
+    @Test
+    public void doesNotMatchIncorrectSessionEntryValue() {
+        assertFalse(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(new Session().withEntry("key1", "value1"))).matches(null, new HttpRequest().withSession(new Session().withEntry("key1", "value2"))));
+    }
+
+    @Test
+    public void doesNotMatchIncorrectSessionEntryValueRegex() {
+        assertFalse(new HttpRequestMatcher(mockServerLogger, new HttpRequest().withSession(new Session().withEntry("key1", "value[0-9]+"))).matches(null, new HttpRequest().withSession(new Session().withEntry("key1", "valueOne"))));
+    }
+
 
     @Test
     public void shouldReturnFormattedRequestWithStringBodyInToString() {

--- a/mockserver-core/src/test/java/org/mockserver/matchers/SessionMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/SessionMatcherTest.java
@@ -1,0 +1,283 @@
+package org.mockserver.matchers;
+
+import org.junit.Test;
+import org.mockserver.logging.MockServerLogger;
+import org.mockserver.model.Session;
+import org.mockserver.model.SessionEntry;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockserver.model.NottableString.not;
+
+
+public class SessionMatcherTest {
+
+    @Test
+    public void shouldMatchSingleSessionMatcherAndSingleMatchingEntry() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1","value1")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1","value1")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldNotMatchSingleSessionMatcherAndSingleNoneMatchingEntry() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1","value1")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("notKey1","value1")
+            )
+        ));
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1","value1")
+        ), false).matches(
+                null,
+                new Session().withEntries(
+                    new SessionEntry("key1","notValue1")
+                )
+        ));
+    }
+
+    @Test
+    public void shouldMatchMultipleSessionMatcherAndMultipleMatchingEntries() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldMatchRegexSessionMatcher() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key.*", "value.*")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldNotMatchMatchingRegexControlPlaneSession() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key.*", "value.*")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldNotMatchMultipleSesisonMatcherAndMultipleNoneMatchingEntriesWithOneMismatch() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("notKey1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "notValue1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldNotMatchMultipleSessionMatcherAndMultipleNoneMatchingEntriesWithMultipleMismatches() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("notKey1", "value1"),
+                new SessionEntry("notKey2", "value2")
+            )
+        ));
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "notValue1"),
+                new SessionEntry("key2", "notValue2")
+            )
+        ));
+
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key.*", "value.*")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("notKey1", "value1"),
+                new SessionEntry("notKey2", "value2")
+            )
+        ));
+
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key.*", "value.*")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "notValue1"),
+                new SessionEntry("key2", "notValue2")
+            )
+        ));
+
+    }
+
+    @Test
+    public void shouldNotMatchMultipleSessionMatcherAndMultipleNotEnoughMatchingEntries() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key2", "value2")
+            )
+        ));
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldMatchMatchingSession() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key.*", "value.*")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldMatchMatchingSessionWithOnlySessionForEmptyList() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session(), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1")
+            )
+        ));
+
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1")
+        ), false).matches(
+            null,
+            new Session()
+        ));
+
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry(not("key1"), not("value1"))
+        ), false).matches(
+            null,
+            new Session()
+        ));
+    }
+
+    @Test
+    public void shouldMatchEmptyExpectation() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session(), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldNotMatchNullEntryValue() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", null)
+            )
+        ));
+    }
+    @Test
+    public void shouldMatchEmptyEntryValueInExpectation() {
+        assertTrue(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1"),
+                new SessionEntry("key2", "value2")
+            )
+        ));
+    }
+
+    @Test
+    public void shouldNotMatchMissingEntry() {
+        assertFalse(new HashMapMatcher(new MockServerLogger(), new Session().withEntries(
+            new SessionEntry("key1", "value1"),
+            new SessionEntry("key2", "value2")
+        ), false).matches(
+            null,
+            new Session().withEntries(
+                new SessionEntry("key1", "value1")
+            )
+        ));
+    }
+
+}

--- a/mockserver-core/src/test/java/org/mockserver/mock/MockServerMatcherClearAndResetTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mock/MockServerMatcherClearAndResetTest.java
@@ -11,6 +11,7 @@ import org.mockserver.model.Cookie;
 import org.mockserver.model.Header;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.Parameter;
+import org.mockserver.model.Session;
 import org.mockserver.scheduler.Scheduler;
 import org.mockserver.ui.MockServerMatcherNotifier;
 
@@ -19,6 +20,8 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.Is.is;
@@ -37,13 +40,15 @@ public class MockServerMatcherClearAndResetTest {
 
     private MockServerMatcher mockServerMatcher;
     private MockServerLogger logFormatter;
+    private Session mockServerSession;
 
     @Before
     public void prepareTestFixture() {
         logFormatter = new MockServerLogger();
         Scheduler scheduler = mock(Scheduler.class);
         WebSocketClientRegistry webSocketClientRegistry = mock(WebSocketClientRegistry.class);
-        mockServerMatcher = new MockServerMatcher(logFormatter, scheduler, webSocketClientRegistry);
+        mockServerSession = new Session();
+        mockServerMatcher = new MockServerMatcher(logFormatter, scheduler, webSocketClientRegistry, mockServerSession);
     }
 
     @Test
@@ -861,6 +866,22 @@ public class MockServerMatcherClearAndResetTest {
 
         // then
         assertThat(mockServerMatcher.httpRequestMatchers.toSortedList(), is(httpRequestMatchers));
+    }
+
+    @Test
+    public void shouldResetAllSessionEntries() {
+        // given
+        mockServerSession
+            .withEntry("key1", "value1")
+            .withEntry("key2", "value2");
+        
+        assertThat(mockServerSession.getMap(), aMapWithSize(2));
+        
+        // when
+        mockServerMatcher.reset();
+
+        // then
+        assertThat(mockServerSession.getMap(), anEmptyMap());
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
@@ -135,7 +135,10 @@ public class HttpRequestTest {
                 "  }," + NEW_LINE +
                 "  \"keepAlive\" : true," + NEW_LINE +
                 "  \"secure\" : true," + NEW_LINE +
-                "  \"body\" : \"some_body\"" + NEW_LINE +
+                "  \"body\" : \"some_body\"," + NEW_LINE +
+                "  \"session\" : {" + NEW_LINE +
+                "    \"some_session_key\" : \"some_session_key_value\"" + NEW_LINE +
+                "  }" + NEW_LINE + 
                 "}",
             request()
                 .withPath("some_path")
@@ -143,6 +146,7 @@ public class HttpRequestTest {
                 .withMethod("METHOD")
                 .withHeaders(new Header("some_header", "some_header_value"))
                 .withCookies(new Cookie("some_cookie", "some_cookie_value"))
+                .withSession(new Session().withEntry("some_session_key", "some_session_key_value"))
                 .withSecure(true)
                 .withQueryStringParameters(new Parameter("some_parameter", "some_parameter_value"))
                 .withKeepAlive(true)
@@ -243,5 +247,17 @@ public class HttpRequestTest {
                 .withKeepAlive(false)
         ));
     }
-
+    
+    @Test
+    public void returnsSessionObject() {
+        Session session = new Session().withEntry("key", "value");
+        HttpRequest httpRequest = request().withSession(session);
+        
+        assertSame(session,httpRequest.getSession());
+    }
+    
+    @Test
+    public void defaultNullSession() {
+        assertNull(new HttpRequest().getSession());
+    }
 }

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
@@ -18,6 +18,8 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.ConnectionOptions.connectionOptions;
 import static org.mockserver.model.HttpResponse.response;
@@ -177,6 +179,9 @@ public class HttpResponseTest {
                 "  \"connectionOptions\" : {" + NEW_LINE +
                 "    \"contentLengthHeaderOverride\" : 10," + NEW_LINE +
                 "    \"keepAliveOverride\" : true" + NEW_LINE +
+                "  }," + NEW_LINE +
+                "  \"session\" : {" + NEW_LINE +
+                "    \"some_session_key\" : \"some_session_key_value\"" + NEW_LINE +
                 "  }" + NEW_LINE +
                 "}",
             response()
@@ -185,6 +190,7 @@ public class HttpResponseTest {
                 .withReasonPhrase("randomPhrase")
                 .withHeaders(new Header("some_header", "some_header_value"))
                 .withCookies(new Cookie("some_cookie", "some_cookie_value"))
+                .withSession(new Session().withEntry("some_session_key", "some_session_key_value"))
                 .withConnectionOptions(
                     connectionOptions()
                         .withContentLengthHeaderOverride(10)
@@ -304,5 +310,18 @@ public class HttpResponseTest {
                         .withKeepAliveOverride(false)
                 )
         ));
+    }
+    
+    @Test
+    public void returnsSessionObject() {
+        Session session = new Session().withEntry("key", "value");
+        HttpResponse httpRsponse = response().withSession(session);
+        
+        assertSame(session,httpRsponse.getSession());
+    }
+    
+    @Test
+    public void defaultNullSession() {
+        assertNull(new HttpResponse().getSession());
     }
 }

--- a/mockserver-core/src/test/java/org/mockserver/model/SessionTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/SessionTest.java
@@ -1,0 +1,127 @@
+package org.mockserver.model;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.junit.Assert.assertThat;
+import static org.mockserver.model.SessionEntry.sessionEntry;
+import static org.mockserver.model.NottableString.not;
+import static org.mockserver.model.NottableString.string;
+
+
+public class SessionTest {
+    @Test
+    public void shouldBuildSessionEntry() {
+        // given
+        Session session = new Session();
+
+        // when
+        SessionEntry entry = session.build(string("key"), string("value"));
+
+        // then
+        assertThat(entry, is(new SessionEntry(string("key"), string("value"))));
+    }
+
+    @Test
+    public void shouldAddEntriesAsSessionVarargs() {
+        // given
+        Session session = new Session();
+
+        // when
+        session.withEntries(
+                sessionEntry("name_one", "value_one"),
+                sessionEntry("name_two", "value_two"),
+                sessionEntry("name_three", "value_three")
+        );
+
+        // then
+        assertThat(session.getEntries().size(), is(3));
+        assertThat(session.getEntries(), hasItems(
+                sessionEntry("name_one", "value_one"),
+                sessionEntry("name_two", "value_two"),
+                sessionEntry("name_three", "value_three")
+        ));
+    }
+
+    @Test
+    public void shouldAddEntriesAsSessionEntryList() {
+        // given
+        Session session = new Session();
+
+        // when
+        session.withEntries(Arrays.asList(
+                sessionEntry("name_one", "value_one"),
+                sessionEntry("name_two", "value_two"),
+                sessionEntry("name_three", "value_three")
+        ));
+
+        // then
+        assertThat(session.getEntries().size(), is(3));
+        assertThat(session.getEntries(), hasItems(
+                sessionEntry("name_one", "value_one"),
+                sessionEntry("name_two", "value_two"),
+                sessionEntry("name_three", "value_three")
+        ));
+    }
+
+    @Test
+    public void shouldAddEntryAsSessionEntry() {
+        // given
+        Session session = new Session();
+
+        // when
+        session.withEntry(sessionEntry("name_one", "value_one"));
+        session.withEntry(sessionEntry("name_two", "value_two"));
+        session.withEntry(sessionEntry("name_three", "value_three"));
+
+        // then
+        assertThat(session.getEntries().size(), is(3));
+        assertThat(session.getEntries(), hasItems(
+                sessionEntry("name_one", "value_one"),
+                sessionEntry("name_two", "value_two"),
+                sessionEntry("name_three", "value_three")
+        ));
+    }
+
+    @Test
+    public void shouldAddEntryAsNameAndValueString() {
+        // given
+        Session session = new Session();
+
+        // when
+        session.withEntry("name_one", "value_one");
+        session.withEntry("name_two", "value_two");
+        session.withEntry("name_three", "value_three");
+
+        // then
+        assertThat(session.getEntries().size(), is(3));
+        assertThat(session.getEntries(), hasItems(
+                sessionEntry("name_one", "value_one"),
+                sessionEntry("name_two", "value_two"),
+                sessionEntry("name_three", "value_three")
+        ));
+    }
+
+    @Test
+    public void shouldAddEntryAsNameAndValueNottableString() {
+        // given
+        Session session = new Session();
+
+        // when
+        session.withEntry(string("name_one"), not("value_one"));
+        session.withEntry(not("name_two"), string("value_two"));
+        session.withEntry(string("name_three"), string("value_three"));
+
+        // then
+        assertThat(session.getEntries().size(), is(3));
+        assertThat(session.getEntries(), hasItems(
+                sessionEntry(string("name_one"), not("value_one")),
+                sessionEntry(not("name_two"), string("value_two")),
+                sessionEntry(string("name_three"), string("value_three"))
+        ));
+    }
+
+}

--- a/mockserver-core/src/test/java/org/mockserver/serialization/ObjectMapperFactoryTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/ObjectMapperFactoryTest.java
@@ -6,6 +6,7 @@ import org.mockserver.matchers.Times;
 import org.mockserver.model.Cookies;
 import org.mockserver.model.Headers;
 import org.mockserver.model.Parameters;
+import org.mockserver.model.Session;
 import org.mockserver.model.StringBody;
 
 import java.io.IOException;
@@ -17,6 +18,7 @@ import static org.mockserver.model.Cookie.cookie;
 import static org.mockserver.model.Header.header;
 import static org.mockserver.model.NottableString.string;
 import static org.mockserver.model.Parameter.param;
+import static org.mockserver.model.SessionEntry.sessionEntry;
 
 /**
  * @author jamesdbloom
@@ -46,6 +48,10 @@ public class ObjectMapperFactoryTest {
             "      \"name\" : \"someCookieName\"," + NEW_LINE +
             "      \"value\" : \"someCookieValue\"" + NEW_LINE +
             "    } ]," + NEW_LINE +
+            "    \"session\" : [ {" + NEW_LINE +
+            "      \"name\" : \"someSessionKey1\"," + NEW_LINE +
+            "      \"value\" : \"someSessionValue1\"" + NEW_LINE +
+            "    } ]," + NEW_LINE +
             "    \"headers\" : [ {" + NEW_LINE +
             "      \"name\" : \"someHeaderName\"," + NEW_LINE +
             "      \"values\" : [ \"someHeaderValue\" ]" + NEW_LINE +
@@ -57,6 +63,10 @@ public class ObjectMapperFactoryTest {
             "    \"cookies\" : [ {" + NEW_LINE +
             "      \"name\" : \"someCookieName\"," + NEW_LINE +
             "      \"value\" : \"someCookieValue\"" + NEW_LINE +
+            "    } ]," + NEW_LINE +
+            "    \"session\" : [ {" + NEW_LINE +
+            "      \"name\" : \"someSessionKey2\"," + NEW_LINE +
+            "      \"value\" : \"someSessionValue2\"" + NEW_LINE +
             "    } ]," + NEW_LINE +
             "    \"headers\" : [ {" + NEW_LINE +
             "      \"name\" : \"someHeaderName\"," + NEW_LINE +
@@ -93,6 +103,9 @@ public class ObjectMapperFactoryTest {
                     .setCookies(new Cookies().withEntries(
                         cookie("someCookieName", "someCookieValue")
                     ))
+                    .setSession(new Session().withEntries(
+                        sessionEntry("someSessionKey1","someSessionValue1")
+                    ))
             )
             .setHttpResponse(
                 new HttpResponseDTO()
@@ -109,6 +122,9 @@ public class ObjectMapperFactoryTest {
                             .setTimeUnit(TimeUnit.MICROSECONDS)
                             .setValue(1)
                     )
+                    .setSession(new Session().withEntries(
+                        sessionEntry("someSessionKey2","someSessionValue2")
+                    ))
             )
             .setTimes(new org.mockserver.serialization.model.TimesDTO(Times.exactly(5))), expectationDTO);
     }


### PR DESCRIPTION
Session is implemented as a Map which is persisted in memory.
Session entries can be set by a http response of a matched expectation.
Existing session entries can be used as an expecation matcher.
This commit includes:
1. adding Session object to HttpRequest and HttpResponse classes.
2. adding matcher for comparing the server session entries against the session entries in an expecation request
3. session entries in matched expecation response are merged to server session - explicit empty session in matched response clears the entire session state.