### PR TITLE
Update HttpClassCallback to support HttpResponse return.

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/model/HttpClassCallback.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpClassCallback.java
@@ -46,7 +46,7 @@ public class HttpClassCallback extends Action<HttpClassCallback> {
      *
      * @param callbackClass class to callback as a fully qualified class name, i.e. "com.foo.MyExpectationResponseCallback"
      */
-    public static HttpClassCallback callback(Class<? extends ExpectationCallback<HttpRequest>> callbackClass) {
+    public static HttpClassCallback callback(Class<? extends ExpectationCallback<? extends HttpObject<?, ?>>> callbackClass) {
         return new HttpClassCallback().withCallbackClass(callbackClass);
     }
 
@@ -83,7 +83,7 @@ public class HttpClassCallback extends Action<HttpClassCallback> {
      *
      * @param callbackClass class to callback as a fully qualified class name, i.e. "com.foo.MyExpectationResponseCallback"
      */
-    public HttpClassCallback withCallbackClass(Class<? extends ExpectationCallback<HttpRequest>> callbackClass) {
+    public HttpClassCallback withCallbackClass(Class<? extends ExpectationCallback<? extends HttpObject<?, ?>>> callbackClass) {
         this.callbackClass = callbackClass.getName();
         return this;
     }

--- a/mockserver-core/src/test/java/org/mockserver/mock/action/HttpResponseClassCallbackActionHandlerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mock/action/HttpResponseClassCallbackActionHandlerTest.java
@@ -42,6 +42,18 @@ public class HttpResponseClassCallbackActionHandlerTest {
         assertThat(actualHttpResponse, is(response("some_body")));
     }
 
+    @Test
+    public void shouldHandleValidLocalClassViaType() {
+        // given
+        HttpClassCallback httpClassCallback = callback(TestCallback.class);
+
+        // when
+        HttpResponse actualHttpResponse = new HttpResponseClassCallbackActionHandler(new MockServerLogger()).handle(httpClassCallback, request().withBody("some_body"));
+
+        // then        
+        assertThat(actualHttpResponse, is(response("some_body")));
+    }
+
     public static class TestCallback implements ExpectationResponseCallback {
 
         @Override

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpClassCallbackTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpClassCallbackTest.java
@@ -2,6 +2,8 @@ package org.mockserver.model;
 
 import junit.framework.TestCase;
 import org.junit.Test;
+import org.mockserver.mock.action.ExpectationForwardCallback;
+import org.mockserver.mock.action.ExpectationResponseCallback;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
@@ -36,5 +38,27 @@ public class HttpClassCallbackTest {
                         .withCallbackClass("some_class")
                         .toString()
         );
+    }
+
+    @Test
+    public void shouldHandleValidExpectationCallbacks() {
+        assertEquals("org.mockserver.model.HttpClassCallbackTest$TestResponseCallback", 
+            new HttpClassCallback().withCallbackClass(TestResponseCallback.class).getCallbackClass());
+        assertEquals("org.mockserver.model.HttpClassCallbackTest$TestForwardCallback", 
+            new HttpClassCallback().withCallbackClass(TestForwardCallback.class).getCallbackClass());
+    }
+
+    public static class TestResponseCallback implements ExpectationResponseCallback {
+        @Override
+        public HttpResponse handle(HttpRequest httpRequest) {
+            return null;
+        }
+    }
+
+    public static class TestForwardCallback implements ExpectationForwardCallback {
+        @Override
+        public HttpRequest handle(HttpRequest httpRequest) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
- This addresses the Issue https://github.com/mock-server/mockserver/issues/762