### PR TITLE
fix: change the length of request static resources

### DIFF
--- a/mockserver-netty/src/main/java/org/mockserver/dashboard/DashboardHandler.java
+++ b/mockserver-netty/src/main/java/org/mockserver/dashboard/DashboardHandler.java
@@ -62,7 +62,7 @@ public class DashboardHandler {
                     response =
                         response()
                             .withHeader(HttpHeaderNames.CONTENT_TYPE.toString(), MIME_MAP.get(extension))
-                            .withHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(content.length()))
+                            .withHeader(HttpHeaderNames.CONTENT_LENGTH.toString(), String.valueOf(content.getBytes().length))
                             .withBody(content);
                 } else {
                     final byte[] bytes = ByteStreams.toByteArray(contentStream);


### PR DESCRIPTION
i use custom page for index, but the browser loads part of one css file, and i find this error cause by the content-length set wrong in header, so the browser get only part of css, this must use String.getBytes.length instead of String.getLength()