### PR TITLE
Fix: document correct mTLS Certificate Chain env variable

### DIFF
--- a/jekyll-www.mock-server.com/mock_server/_includes/tls_configuration.html
+++ b/jekyll-www.mock-server.com/mock_server/_includes/tls_configuration.html
@@ -205,7 +205,7 @@
     <p>System Property:</p>
     <pre class="code" style="padding: 2px;"><code class="code">-Dmockserver.tlsMutualAuthenticationCertificateChain=...</code></pre>
     <p>Environment Variable:</p>
-    <pre class="code" style="padding: 2px;"><code class="code">MOCKSERVER_FORWARD_PROXY_TLS_X509_CERTIFICATE_CHAIN=...</code></pre>
+    <pre class="code" style="padding: 2px;"><code class="code">MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN=...</code></pre>
     <p>Property File:</p>
     <pre class="code" style="padding: 2px;"><code class="code">mockserver.tlsMutualAuthenticationCertificateChain=...</code></pre>
     <p>Example:</p>


### PR DESCRIPTION
Adapted the documentation to include the correct environment variable for setting the path to the certificate chain to be used for mTLS (referenced the forward proxy certificate chain variable previously).