### PR TITLE
Fixing concurrency issues for velocity response templates

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngine.java
+++ b/mockserver-core/src/main/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngine.java
@@ -13,6 +13,7 @@ import org.slf4j.event.Level;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
+import javax.script.SimpleScriptContext;
 import java.io.StringWriter;
 import java.io.Writer;
 
@@ -44,10 +45,10 @@ public class VelocityTemplateEngine implements TemplateEngine {
         T result;
         try {
             Writer writer = new StringWriter();
-            ScriptContext context = engine.getContext();
+            ScriptContext context = new SimpleScriptContext();
             context.setWriter(writer);
             context.setAttribute("request", new HttpRequestTemplateObject(request), ScriptContext.ENGINE_SCOPE);
-            engine.eval(template);
+            engine.eval(template, context);
             logFormatter.logEvent(
                 new LogEntry()
                     .setType(TEMPLATE_GENERATED)


### PR DESCRIPTION
This is address the concurrency issues for velocity HTTP response templates. This change will partly address the issue mentioned on https://github.com/mock-server/mockserver/issues/779