### PR TITLE
Including "never" verification times

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/verify/VerificationTimes.java
+++ b/mockserver-core/src/main/java/org/mockserver/verify/VerificationTimes.java
@@ -15,6 +15,10 @@ public class VerificationTimes extends ObjectWithReflectiveEqualsHashCodeToStrin
         this.atLeast = atLeast;
     }
 
+    public static VerificationTimes never() {
+        return new VerificationTimes(0, 0);
+    }
+
     public static VerificationTimes once() {
         return new VerificationTimes(1, 1);
     }
@@ -55,7 +59,9 @@ public class VerificationTimes extends ObjectWithReflectiveEqualsHashCodeToStrin
         String string = "";
         if (atLeast == atMost) {
             string += "exactly ";
-            if (atMost == 1) {
+            if (atMost == 0) {
+                string += "never";
+            } else if (atMost == 1) {
                 string += "once";
             } else {
                 string += atMost + " times";

--- a/mockserver-core/src/main/java/org/mockserver/verify/VerificationTimes.java
+++ b/mockserver-core/src/main/java/org/mockserver/verify/VerificationTimes.java
@@ -59,9 +59,7 @@ public class VerificationTimes extends ObjectWithReflectiveEqualsHashCodeToStrin
         String string = "";
         if (atLeast == atMost) {
             string += "exactly ";
-            if (atMost == 0) {
-                string += "never";
-            } else if (atMost == 1) {
+            if (atMost == 1) {
                 string += "once";
             } else {
                 string += atMost + " times";

--- a/mockserver-core/src/test/java/org/mockserver/serialization/model/VerificationTimesDTOTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/model/VerificationTimesDTOTest.java
@@ -21,7 +21,14 @@ public class VerificationTimesDTOTest {
     @Test
     public void shouldBuildCorrectObject() {
         // when
-        VerificationTimes times = new VerificationTimesDTO(VerificationTimes.once()).buildObject();
+        VerificationTimes times = new VerificationTimesDTO(VerificationTimes.never()).buildObject();
+
+        // then
+        assertThat(times.getAtLeast(), is(0));
+        assertThat(times.getAtMost(), is(0));
+
+        // when
+        times = new VerificationTimesDTO(VerificationTimes.once()).buildObject();
 
         // then
         assertThat(times.getAtLeast(), is(1));

--- a/mockserver-core/src/test/java/org/mockserver/serialization/serializers/condition/VerificationTimesDTOSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/serializers/condition/VerificationTimesDTOSerializerTest.java
@@ -31,6 +31,21 @@ public class VerificationTimesDTOSerializerTest {
     }
 
     @Test
+    public void shouldSerializeNever() throws JsonProcessingException {
+    assertThat(ObjectMapperFactory
+                .createObjectMapper(true)
+                .writeValueAsString(
+                    new VerificationTimesDTO(
+                        never()
+                    )
+                ),
+            is("{" + NEW_LINE +
+                "  \"atLeast\" : 0," + NEW_LINE +
+                "  \"atMost\" : 0" + NEW_LINE +
+                "}"));
+    }
+
+    @Test
     public void shouldSerializeOnce() throws JsonProcessingException {
         assertThat(ObjectMapperFactory
                 .createObjectMapper(true)

--- a/mockserver-core/src/test/java/org/mockserver/serialization/serializers/condition/VerificationTimesSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/serializers/condition/VerificationTimesSerializerTest.java
@@ -28,6 +28,19 @@ public class VerificationTimesSerializerTest {
     }
 
     @Test
+    public void shouldSerializeNever() throws JsonProcessingException {
+        assertThat(ObjectMapperFactory
+                .createObjectMapper(true)
+                .writeValueAsString(
+                    never()
+                ),
+            is("{" + NEW_LINE +
+                "  \"atLeast\" : 0," + NEW_LINE +
+                "  \"atMost\" : 0" + NEW_LINE +
+                "}"));
+    }
+
+    @Test
     public void shouldSerializeOnce() throws JsonProcessingException {
         assertThat(ObjectMapperFactory
                 .createObjectMapper(true)

--- a/mockserver-core/src/test/java/org/mockserver/verify/VerificationTimesTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/verify/VerificationTimesTest.java
@@ -134,9 +134,9 @@ public class VerificationTimesTest {
     @Test
     public void shouldGenerateCorrectToString() {
         // then
-        assertThat(never().toString(), is("exactly never"));
+        assertThat(never().toString(), is("exactly 0 times"));
         assertThat(once().toString(), is("exactly once"));
-        assertThat(exactly(0).toString(), is("exactly never"));
+        assertThat(exactly(0).toString(), is("exactly 0 times"));
         assertThat(exactly(1).toString(), is("exactly once"));
         assertThat(exactly(2).toString(), is("exactly 2 times"));
         assertThat(atLeast(0).toString(), is("at least 0 times"));

--- a/mockserver-core/src/test/java/org/mockserver/verify/VerificationTimesTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/verify/VerificationTimesTest.java
@@ -32,6 +32,16 @@ public class VerificationTimesTest {
     }
 
     @Test
+    public void shouldCreateCorrectObjectForNever() {
+        // when
+        VerificationTimes times = never();
+
+        //then
+        assertThat(times.getAtLeast(), is(0));
+        assertThat(times.getAtMost(), is(0));
+    }
+
+    @Test
     public void shouldCreateCorrectObjectForOnce() {
         // when
         VerificationTimes times = once();
@@ -124,8 +134,9 @@ public class VerificationTimesTest {
     @Test
     public void shouldGenerateCorrectToString() {
         // then
+        assertThat(never().toString(), is("exactly never"));
         assertThat(once().toString(), is("exactly once"));
-        assertThat(exactly(0).toString(), is("exactly 0 times"));
+        assertThat(exactly(0).toString(), is("exactly never"));
         assertThat(exactly(1).toString(), is("exactly once"));
         assertThat(exactly(2).toString(), is("exactly 2 times"));
         assertThat(atLeast(0).toString(), is("at least 0 times"));


### PR DESCRIPTION
I'd wanted to include "never" as verification time as mockito does. I think that it could make easy to read (compare with "exactly(0)")