### PR TITLE
Fix failing tests due to temporary file path (#940)

### DIFF
--- a/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/tls/inbound/ClientAuthenticationDynamicCAMockingIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/tls/inbound/ClientAuthenticationDynamicCAMockingIntegrationTest.java
@@ -24,7 +24,7 @@ public class ClientAuthenticationDynamicCAMockingIntegrationTest extends Abstrac
     public static void startServer() throws Exception {
         tlsMutualAuthenticationRequired(true);
         dynamicallyCreateCertificateAuthorityCertificate(true);
-        File temporaryDirectory = new File(File.createTempFile("random", "temp").getParent() + UUIDService.getUUID());
+        File temporaryDirectory = new File(File.createTempFile("random", "temp").getParent(), UUIDService.getUUID());
         temporaryDirectory.mkdirs();
         directoryToSaveDynamicSSLCertificate(temporaryDirectory.getAbsolutePath());
         Main.main("-serverPort", "" + severHttpPort);

--- a/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/tls/inbound/bouncycastle/ClientAuthenticationDynamicCAMockingIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/tls/inbound/bouncycastle/ClientAuthenticationDynamicCAMockingIntegrationTest.java
@@ -24,7 +24,7 @@ public class ClientAuthenticationDynamicCAMockingIntegrationTest extends Abstrac
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public static void startServer() throws Exception {
         // temporary directory
-        File temporaryDirectory = new File(File.createTempFile("random", "temp").getParent() + UUIDService.getUUID());
+        File temporaryDirectory = new File(File.createTempFile("random", "temp").getParent(), UUIDService.getUUID());
         temporaryDirectory.mkdirs();
 
         useBouncyCastleForKeyAndCertificateGeneration(true);


### PR DESCRIPTION
A simple change which fixes the test failures.