### PR TITLE
Fix flaky test HttpResponseTest#shouldReturnFormattedRequestInToString

### DIFF
--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -228,6 +228,12 @@
             <artifactId>spring-web</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpResponseTest.java
@@ -1,7 +1,9 @@
 package org.mockserver.model;
 
+import org.json.JSONException;
 import org.junit.Test;
 import org.mockserver.serialization.Base64Converter;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -26,6 +28,14 @@ import static org.mockserver.model.HttpResponse.response;
  * @author jamesdbloom
  */
 public class HttpResponseTest {
+
+    public void assertJsonEqualsNonStrict(String json1, String json2) {
+        try {
+            JSONAssert.assertEquals(json1, json2, false);
+        } catch (JSONException jse) {
+            throw new IllegalArgumentException(jse.getMessage());
+        }
+    }
 
     private final Base64Converter base64Converter = new Base64Converter();
 
@@ -156,7 +166,7 @@ public class HttpResponseTest {
 
     @Test
     public void shouldReturnFormattedRequestInToString() {
-        assertEquals("{" + NEW_LINE +
+        assertJsonEqualsNonStrict("{" + NEW_LINE +
                 "  \"statusCode\" : 666," + NEW_LINE +
                 "  \"reasonPhrase\" : \"randomPhrase\"," + NEW_LINE +
                 "  \"headers\" : {" + NEW_LINE +


### PR DESCRIPTION
The test `HttpResponseTest#shouldReturnFormattedRequestInToString` compares the result of `HttpResponse.response` to a hard-coded string. However, the function `HttpResponse.response` does not return the deterministic string. 

From code trace, the root cause is at `ObjectWithJsonToString.toString`. It uses `jackson.databind.ObjectWriter.writeValueAsString` to serialize objects into json. However, the order of serialized json is not guaranteed so tests may fail if the order differs.

The PR proposes to use library like [JSONassert](https://github.com/skyscreamer/JSONassert) to avoid nondeterministic json string problem.