### PR TITLE
Fix CORS with credentials

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/cors/CORSHeaders.java
+++ b/mockserver-core/src/main/java/org/mockserver/cors/CORSHeaders.java
@@ -19,14 +19,23 @@ public class CORSHeaders {
 
     private final String corsAllowHeaders;
     private final String corsAllowMethods;
-    private final String corsAllowCredentials;
+    private final boolean corsAllowCredentials;
     private final String corsMaxAge;
 
+    public CORSHeaders(String corsAllowHeaders, String corsAllowMethods, boolean corsAllowCredentials, int corsMaxAge) {
+        this.corsAllowHeaders = corsAllowHeaders;
+        this.corsAllowMethods = corsAllowMethods;
+        this.corsAllowCredentials = corsAllowCredentials;
+        this.corsMaxAge = "" + corsMaxAge;
+    }
+
+
     public CORSHeaders() {
-        corsAllowHeaders = ConfigurationProperties.corsAllowHeaders();
-        corsAllowMethods = ConfigurationProperties.corsAllowMethods();
-        corsAllowCredentials = "" + ConfigurationProperties.corsAllowCredentials();
-        corsMaxAge = "" + ConfigurationProperties.corsMaxAgeInSeconds();
+        // Default constuctor builds from the ConfigurationProperties
+        this(ConfigurationProperties.corsAllowHeaders(),
+                ConfigurationProperties.corsAllowMethods(),
+                ConfigurationProperties.corsAllowCredentials(),
+                ConfigurationProperties.corsMaxAgeInSeconds());
     }
 
     public static boolean isPreflightRequest(HttpRequest request) {
@@ -44,9 +53,9 @@ public class CORSHeaders {
         String origin = request.getFirstHeader(HttpHeaderNames.ORIGIN.toString());
         if (NULL_ORIGIN.equals(origin)) {
             setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), NULL_ORIGIN);
-        } else if (!origin.isEmpty() && request.getFirstHeader(HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString()).equals("true")) {
+        } else if (!origin.isEmpty() && corsAllowCredentials) {
             setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), origin);
-            setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), corsAllowCredentials);
+            setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_CREDENTIALS.toString(), "true");
         } else {
             setHeaderIfNotAlreadyExists(response, HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), ANY_ORIGIN);
         }

--- a/mockserver-core/src/test/java/org/mockserver/cors/CORSHeadersTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/cors/CORSHeadersTest.java
@@ -49,9 +49,15 @@ public class CORSHeadersTest {
         // given
         HttpRequest request = request();
         HttpResponse response = response();
+        CORSHeaders corsHeaders = new CORSHeaders(
+            "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization",
+            "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE",
+            true,
+            300
+        );
 
         // when
-        new CORSHeaders().addCORSHeaders(request, response);
+        corsHeaders.addCORSHeaders(request, response);
 
         // then
         assertThat(response.getFirstHeader("access-control-allow-origin"), is("*"));
@@ -67,9 +73,16 @@ public class CORSHeadersTest {
         HttpRequest request = request()
             .withHeader("origin", "null");
         HttpResponse response = response();
+        CORSHeaders corsHeaders = new CORSHeaders(
+            "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization",
+            "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE",
+            true,
+            300
+        );
+
 
         // when
-        new CORSHeaders().addCORSHeaders(request, response);
+        corsHeaders.addCORSHeaders(request, response);
 
         // then
         assertThat(response.getFirstHeader("access-control-allow-origin"), is("null"));
@@ -83,15 +96,22 @@ public class CORSHeadersTest {
     public void shouldAddCORSHeaderForAllowCredentials() {
         // given
         HttpRequest request = request()
-            .withHeader("origin", "some_origin_value")
-            .withHeader("access-control-allow-credentials", "true");
+            .withHeader("origin", "some_origin_value");
         HttpResponse response = response();
+        CORSHeaders corsHeaders = new CORSHeaders(
+            "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization",
+            "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE",
+            true,
+            300
+        );
+
 
         // when
-        new CORSHeaders().addCORSHeaders(request, response);
+        corsHeaders.addCORSHeaders(request, response);
 
         // then
         assertThat(response.getFirstHeader("access-control-allow-origin"), is("some_origin_value"));
+        assertThat(response.getFirstHeader("access-control-allow-credentials"), is("true"));
         assertThat(response.getFirstHeader("access-control-allow-methods"), is("CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE"));
         assertThat(response.getFirstHeader("access-control-allow-headers"), is("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization"));
         assertThat(response.getFirstHeader("access-control-expose-headers"), is("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization"));
@@ -101,12 +121,18 @@ public class CORSHeadersTest {
     @Test
     public void shouldAddCORSHeaderForAllowCredentialsWithoutOrigin() {
         // given
-        HttpRequest request = request()
-            .withHeader("access-control-allow-credentials", "true");
+        HttpRequest request = request();
         HttpResponse response = response();
+        CORSHeaders corsHeaders = new CORSHeaders(
+            "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization",
+            "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE",
+            true,
+            300
+        );
+
 
         // when
-        new CORSHeaders().addCORSHeaders(request, response);
+        corsHeaders.addCORSHeaders(request, response);
 
         // then
         assertThat(response.getFirstHeader("access-control-allow-origin"), is("*"));
@@ -123,9 +149,16 @@ public class CORSHeadersTest {
             .withMethod("OPTIONS")
             .withHeader("Access-Control-Request-Headers", "X-API-Key");
         HttpResponse response = response();
+        CORSHeaders corsHeaders = new CORSHeaders(
+            "Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization",
+            "CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE",
+            true,
+            300
+        );
+
 
         // when
-        new CORSHeaders().addCORSHeaders(request, response);
+        corsHeaders.addCORSHeaders(request, response);
 
         // then
         assertThat(response.getFirstHeader("access-control-allow-headers"), containsString("X-API-Key"));

--- a/mockserver-netty/src/test/java/org/mockserver/cors/OverridePreFlightRequestIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/cors/OverridePreFlightRequestIntegrationTest.java
@@ -101,7 +101,7 @@ public class OverridePreFlightRequestIntegrationTest {
         // then
         HttpResponse httpResponse = responseFuture.get(10, TimeUnit.SECONDS);
         assertThat(httpResponse.getStatusCode(), is(200));
-        assertThat(httpResponse.getHeader("access-control-allow-origin"), containsInAnyOrder("*"));
+        assertThat(httpResponse.getHeader("access-control-allow-origin"), containsInAnyOrder("http://localhost:8000"));
         assertThat(httpResponse.getHeader("access-control-allow-methods"), containsInAnyOrder("CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE"));
         assertThat(httpResponse.getHeader("access-control-allow-headers"), containsInAnyOrder("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization, extra-header, other-extra-header"));
         assertThat(httpResponse.getHeader("access-control-expose-headers"), containsInAnyOrder("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization, extra-header, other-extra-header"));

--- a/mockserver-netty/src/test/java/org/mockserver/cors/OverridePreFlightRequestIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/cors/OverridePreFlightRequestIntegrationTest.java
@@ -74,7 +74,7 @@ public class OverridePreFlightRequestIntegrationTest {
         // then
         HttpResponse response = responseFuture.get(10, TimeUnit.SECONDS);
         assertThat(response.getStatusCode(), is(200));
-        assertThat(response.getHeader("access-control-allow-origin"), containsInAnyOrder("*"));
+        assertThat(response.getHeader("access-control-allow-origin"), containsInAnyOrder("http://127.0.0.1:1234"));
         assertThat(response.getHeader("access-control-allow-methods"), containsInAnyOrder("CONNECT, DELETE, GET, HEAD, OPTIONS, POST, PUT, PATCH, TRACE"));
         assertThat(response.getHeader("access-control-allow-headers"), containsInAnyOrder("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization"));
         assertThat(response.getHeader("access-control-expose-headers"), containsInAnyOrder("Allow, Content-Encoding, Content-Length, Content-Type, ETag, Expires, Last-Modified, Location, Server, Vary, Authorization"));


### PR DESCRIPTION
Mockserver expects a `Access-Control-Allow-Credentials in their preflight request.` to include the `Access-Control-Allow-Credentials: true | false` header. But the header is never sent. Additionaly when `Access-Control-Allow-Credentials`, the header `
access-control-allow-origin` cannot be `'*'`


cf #401 #505 