### PR TITLE
Fix importing custom resource quotas in helm chart

### DIFF
--- a/helm/mockserver/templates/deployment.yaml
+++ b/helm/mockserver/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
               mountPath: /config
             - name: libs-volume
               mountPath: /libs
-{{- if .Values.app.resources }}
+{{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Seems that there's a bug in a Helm chart. When "resources" are defined in custom values, they're not imported until there's `app.resources` value, like this:

Original (not working):

```yaml
resources:
  requests:
    memory: "384Mi"
    cpu: "300m"
  limits:
    memory: "1Gi"
    cpu: "1000m"
```
Workaround (working, but seems odd):

```yaml
app:
  resources: true
resources:
  requests:
    memory: "384Mi"
    cpu: "300m"
  limits:
    memory: "1Gi"
    cpu: "1000m"
```
