### PR TITLE
fix(?): replace .Values.app.resources with .Values.resources in deployment.yaml

### DIFF
--- a/helm/mockserver/templates/deployment.yaml
+++ b/helm/mockserver/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
               mountPath: /config
             - name: libs-volume
               mountPath: /libs
-{{- if .Values.app.resources }}
+{{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Hi
I've noticed that in deployment.yaml there is inconsistency in configuration of resources. Property `.Values.app.resources` is used as condition in if statement, but then `.Values.resources` is used as value. I suppose that this is a typo, because otherwise to configure resources you have to do something like:

```
app.resources: true

resources:
  limits:
    cpu: 500m
    memory: 512Mi
  requests:
    cpu: 500m
    memory: 512Mi
```

Which is rather unusual for helm charts