### PR TITLE
Bump velocity to 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <jetty.version>9.4.35.v20201120</jetty.version>
         <slf4j.version>1.7.30</slf4j.version>
         <jackson.version>2.11.3</jackson.version>
-        <velocity.version>2.2</velocity.version>
+        <velocity.version>2.3</velocity.version>
         <netty.version>4.1.55.Final</netty.version>
         <httpcomponents.version>4.4.1</httpcomponents.version>
         <boucycastle.verion>1.67</boucycastle.verion>


### PR DESCRIPTION
Fixes CVE-2020-13936 / SNYK-JAVA-ORGAPACHEVELOCITY-1083992

The fix in Velocity is https://github.com/apache/velocity-engine/pull/16

Closes https://github.com/mock-server/mockserver/issues/1006