### PR TITLE
Issue #791, Clear by expectation id

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/model/RequestDefinition.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/RequestDefinition.java
@@ -10,6 +10,17 @@ public abstract class RequestDefinition extends Not {
 
     private String logCorrelationId;
 
+    // present for expectation id(key), used for "/mockserver/clear" - api
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     @JsonIgnore
     public String getLogCorrelationId() {
         return logCorrelationId;


### PR DESCRIPTION
Clear by expectation id

you can clear specific expectation with id (key) like:

`curl -XPUT "http://${mockserver_host}/mockserver/clear?type=EXPECTATIONS" -d '{"id":"d738feee-ae94-4a3d-81d9-4204fe133a49"}'
` ​

which id is expectation's id(key)

