### PR TITLE
Do not treat ndjson as json

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/model/MediaType.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/MediaType.java
@@ -254,6 +254,8 @@ public class MediaType extends ObjectWithJsonToString {
     public boolean isJson() {
         return !isBlank && contentTypeContains(new String[]{
             "json"
+        }) && !contentTypeContains(new String[]{
+            "ndjson"
         });
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/model/MediaTypeTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/MediaTypeTest.java
@@ -328,6 +328,17 @@ public class MediaTypeTest {
     }
 
     @Test
+    public void shouldNotDetectAsJson() {
+        List<String> jsonContentTypes = Arrays.asList(
+            "application/x-ndjson"
+        );
+        for (String contentType : jsonContentTypes) {
+            MediaType parse = MediaType.parse(contentType);
+            assertThat(contentType + " should not be json", parse.isJson(), is(false));
+        }
+    }
+
+    @Test
     public void shouldDetectAsXml() {
         List<String> xmlContentTypes = Arrays.asList(
             "application/xml",


### PR DESCRIPTION
`org.mockserver.client.MockServerClient#retrieveRecordedRequests(org.mockserver.model.RequestDefinition)` returns only the first json object (instead of all) when the content type is `application/x-ndjson`, so do not treat `application/x-ndjson` as json.