### PR TITLE
Mockserver client to use JVM truststore by configuration.

### DIFF
--- a/jekyll-www.mock-server.com/mock_server/_includes/tls_configuration.html
+++ b/jekyll-www.mock-server.com/mock_server/_includes/tls_configuration.html
@@ -335,9 +335,9 @@
     <pre class="code" style="padding: 2px;"><code class="code">-Dmockserver.tlsMutualAuthenticationCertificateChain="/some/existing/path"</code></pre>
 </div>
 
-<button id="button_configuration_mockserver_client_use_jvm_truststore" class="accordion title"><strong>Inbound TLS X.509 Trusted Certificates (for Trusting Client X.509 Certificates)</strong></button>
+<button id="button_configuration_mockserver_client_use_jvm_truststore" class="accordion title"><strong>Inbound TLS X.509 JVM Trusted Certificates</strong></button>
 <div class="panel title">
-    <p>Use JVM X.509 Certificates Trust Store for trusting custom certificates. This the trusted certificates will only be used if MockServerClient performs TLS to calls to MockServer.</p>
+    <p>Use JVM X.509 Certificates Trust Store for trusting custom certificates. The trusted certificates will only be used if MockServerClient performs TLS to calls to MockServer.</p>
     <p>Type: <span class="keyword">boolean</span> Default: <span class="this_value">false</span></p>
     <p>Java Code:</p>
     <pre class="code" style="padding: 2px;"><code class="code">ConfigurationProperties.useJvmTrustCertificates(boolean use)</code></pre>

--- a/jekyll-www.mock-server.com/mock_server/_includes/tls_configuration.html
+++ b/jekyll-www.mock-server.com/mock_server/_includes/tls_configuration.html
@@ -335,6 +335,22 @@
     <pre class="code" style="padding: 2px;"><code class="code">-Dmockserver.tlsMutualAuthenticationCertificateChain="/some/existing/path"</code></pre>
 </div>
 
+<button id="button_configuration_mockserver_client_use_jvm_truststore" class="accordion title"><strong>Inbound TLS X.509 Trusted Certificates (for Trusting Client X.509 Certificates)</strong></button>
+<div class="panel title">
+    <p>Use JVM X.509 Certificates Trust Store for trusting custom certificates. This the trusted certificates will only be used if MockServerClient performs TLS to calls to MockServer.</p>
+    <p>Type: <span class="keyword">boolean</span> Default: <span class="this_value">false</span></p>
+    <p>Java Code:</p>
+    <pre class="code" style="padding: 2px;"><code class="code">ConfigurationProperties.useJvmTrustCertificates(boolean use)</code></pre>
+    <p>System Property:</p>
+    <pre class="code" style="padding: 2px;"><code class="code">-Dmockserver.useJvmTrustCertificates=...</code></pre>
+    <p>Environment Variable:</p>
+    <pre class="code" style="padding: 2px;"><code class="code">MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES=...</code></pre>
+    <p>Property File:</p>
+    <pre class="code" style="padding: 2px;"><code class="code">mockserver.useJvmTrustCertificates=...</code></pre>
+    <p>Example:</p>
+    <pre class="code" style="padding: 2px;"><code class="code">-Dmockserver.useJvmTrustCertificates="true"</code></pre>
+</div>
+
 <a id="tls_configuration_bouncy_castle" class="anchor" href="#tls_configuration_bouncy_castle">&nbsp;</a>
 
 <h4>Bouncy Castle</h4>

--- a/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -57,6 +57,7 @@ public class ConfigurationProperties {
     private static final String DEFAULT_MOCKSERVER_DYNAMICALLY_CREATE_CERTIFICATE_AUTHORITY_CERTIFICATE = "false";
     private static final String DEFAULT_TLS_MUTUAL_AUTHENTICATION_REQUIRED = "false";
     private static final String DEFAULT_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN = "";
+    private static final String DEFAULT_TLS_USE_JVM_TRUST_CERTIFICATES = "false";
     private static final String DEFAULT_FORWARD_PROXY_TLS_X509_CERTIFICATES_TRUST_MANAGER_TYPE = "ANY";
     private static final String DEFAULT_FORWARD_PROXY_TLS_CUSTOM_TRUST_X509_CERTIFICATES = "";
     private static final String DEFAULT_FORWARD_PROXY_TLS_PRIVATE_KEY = "";
@@ -97,6 +98,7 @@ public class ConfigurationProperties {
     private static final String MOCKSERVER_DYNAMICALLY_CREATE_CERTIFICATE_AUTHORITY_CERTIFICATE = "mockserver.dynamicallyCreateCertificateAuthorityCertificate";
     private static final String MOCKSERVER_CERTIFICATE_DIRECTORY_TO_SAVE_DYNAMIC_SSL_CERTIFICATE = "mockserver.directoryToSaveDynamicSSLCertificate";
     private static final String MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED = "mockserver.tlsMutualAuthenticationRequired";
+    private static final String MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES = "mockserver.useJvmTrustCertificates";
     private static final String MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN = "mockserver.tlsMutualAuthenticationCertificateChain";
     private static final String MOCKSERVER_FORWARD_PROXY_TLS_X509_CERTIFICATES_TRUST_MANAGER_TYPE = "mockserver.forwardProxyTLSX509CertificatesTrustManagerType";
     private static final String MOCKSERVER_FORWARD_PROXY_TLS_CUSTOM_TRUST_X509_CERTIFICATES = "mockserver.forwardProxyTLSCustomTrustX509Certificates";
@@ -212,6 +214,7 @@ public class ConfigurationProperties {
     private static boolean attemptToProxyIfNoMatchingExpectation = Boolean.parseBoolean(readPropertyHierarchically(MOCKSERVER_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION, "MOCKSERVER_ATTEMPT_TO_PROXY_IF_NO_MATCHING_EXPECTATION", "" + true));
     private static boolean enableMTLS = Boolean.parseBoolean(readPropertyHierarchically(MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED, "MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED", DEFAULT_TLS_MUTUAL_AUTHENTICATION_REQUIRED));
     private static String tlsMutualAuthenticationCertificateChain = readPropertyHierarchically(MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN, "MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN", DEFAULT_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN);
+    private static boolean useJvmTrustCertificates = Boolean.parseBoolean(readPropertyHierarchically(MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES, "MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES", DEFAULT_TLS_USE_JVM_TRUST_CERTIFICATES));
     private static ForwardProxyTLSX509CertificatesTrustManager forwardProxyTLSX509CertificatesTrustManagerType = validateTrustManagerType(readPropertyHierarchically(MOCKSERVER_FORWARD_PROXY_TLS_X509_CERTIFICATES_TRUST_MANAGER_TYPE, "MOCKSERVER_FORWARD_PROXY_TLS_X509_CERTIFICATES_TRUST_MANAGER_TYPE", DEFAULT_FORWARD_PROXY_TLS_X509_CERTIFICATES_TRUST_MANAGER_TYPE));
     private static String forwardProxyTLSCustomTrustX509Certificates = readPropertyHierarchically(MOCKSERVER_FORWARD_PROXY_TLS_CUSTOM_TRUST_X509_CERTIFICATES, "MOCKSERVER_FORWARD_PROXY_TLS_CUSTOM_TRUST_X509_CERTIFICATES", DEFAULT_FORWARD_PROXY_TLS_CUSTOM_TRUST_X509_CERTIFICATES);
     private static String forwardProxyPrivateKey = readPropertyHierarchically(MOCKSERVER_FORWARD_PROXY_TLS_PRIVATE_KEY, "MOCKSERVER_FORWARD_PROXY_TLS_PRIVATE_KEY", DEFAULT_FORWARD_PROXY_TLS_PRIVATE_KEY);
@@ -659,6 +662,20 @@ public class ConfigurationProperties {
 
     public static String tlsMutualAuthenticationCertificateChain() {
         return tlsMutualAuthenticationCertificateChain;
+    }
+
+    /**
+     * Use JVM Trust Store for Trusting (i.e. signature verification of) Client X.509 Certificates.
+     *
+     * @param use JVM Trust Store
+     */
+    public static void useJvmTrustCertificates(boolean use) {
+        System.setProperty(MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES, "" + use);
+        useJvmTrustCertificates = Boolean.parseBoolean(readPropertyHierarchically(MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES, "MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES", DEFAULT_TLS_USE_JVM_TRUST_CERTIFICATES));
+    }
+
+    public static boolean useJvmTrustCertificates() {
+        return useJvmTrustCertificates;
     }
 
     /**

--- a/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -98,8 +98,8 @@ public class ConfigurationProperties {
     private static final String MOCKSERVER_DYNAMICALLY_CREATE_CERTIFICATE_AUTHORITY_CERTIFICATE = "mockserver.dynamicallyCreateCertificateAuthorityCertificate";
     private static final String MOCKSERVER_CERTIFICATE_DIRECTORY_TO_SAVE_DYNAMIC_SSL_CERTIFICATE = "mockserver.directoryToSaveDynamicSSLCertificate";
     private static final String MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED = "mockserver.tlsMutualAuthenticationRequired";
-    private static final String MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES = "mockserver.useJvmTrustCertificates";
     private static final String MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_CERTIFICATE_CHAIN = "mockserver.tlsMutualAuthenticationCertificateChain";
+    private static final String MOCKSERVER_TLS_USE_JVM_TRUST_CERTIFICATES = "mockserver.useJvmTrustCertificates";
     private static final String MOCKSERVER_FORWARD_PROXY_TLS_X509_CERTIFICATES_TRUST_MANAGER_TYPE = "mockserver.forwardProxyTLSX509CertificatesTrustManagerType";
     private static final String MOCKSERVER_FORWARD_PROXY_TLS_CUSTOM_TRUST_X509_CERTIFICATES = "mockserver.forwardProxyTLSCustomTrustX509Certificates";
     private static final String MOCKSERVER_FORWARD_PROXY_TLS_PRIVATE_KEY = "mockserver.forwardProxyPrivateKey";

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
@@ -81,9 +81,7 @@ public class NettySslContextFactory {
                             break;
                     }
                 } else {
-                    sslContextBuilder.trustManager(
-                        concatX509Certificates(jvmCAX509TrustCertificates(), trustCertificateChain())
-                    );
+                    sslContextBuilder.trustManager(getX509TrustCertificates());
                 }
                 clientSslContext = clientSslContextBuilderFunction
                     .apply(sslContextBuilder);
@@ -93,6 +91,16 @@ public class NettySslContextFactory {
             }
         }
         return clientSslContext;
+    }
+
+    private X509Certificate[] getX509TrustCertificates() throws NoSuchAlgorithmException, KeyStoreException {
+        X509Certificate[] trustCerts;
+        if (ConfigurationProperties.useJvmTrustCertificates()) {
+            trustCerts = concatX509Certificates(jvmCAX509TrustCertificates(), trustCertificateChain());
+        } else {
+            trustCerts = trustCertificateChain();
+        }
+        return trustCerts;
     }
 
     private X509Certificate[] concatX509Certificates(X509Certificate[] first, X509Certificate[] second) {

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
@@ -82,7 +82,7 @@ public class NettySslContextFactory {
                     }
                 } else {
                     sslContextBuilder.trustManager(
-                        mergeX509Certificates(jvmCAX509TrustCertificates(), trustCertificateChain())
+                        concatX509Certificates(jvmCAX509TrustCertificates(), trustCertificateChain())
                     );
                 }
                 clientSslContext = clientSslContextBuilderFunction
@@ -95,7 +95,7 @@ public class NettySslContextFactory {
         return clientSslContext;
     }
 
-    private X509Certificate[] mergeX509Certificates(X509Certificate[] first, X509Certificate[] second) {
+    private X509Certificate[] concatX509Certificates(X509Certificate[] first, X509Certificate[] second) {
         X509Certificate[] merged = Arrays.copyOf(first, first.length + second.length);
         System.arraycopy(second, 0, merged, first.length, second.length);
         return merged;

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
@@ -81,7 +81,9 @@ public class NettySslContextFactory {
                             break;
                     }
                 } else {
-                    sslContextBuilder.trustManager(trustCertificateChain());
+                    sslContextBuilder.trustManager(
+                        mergeX509Certificates(jvmCAX509TrustCertificates(), trustCertificateChain())
+                    );
                 }
                 clientSslContext = clientSslContextBuilderFunction
                     .apply(sslContextBuilder);
@@ -91,6 +93,12 @@ public class NettySslContextFactory {
             }
         }
         return clientSslContext;
+    }
+
+    private X509Certificate[] mergeX509Certificates(X509Certificate[] first, X509Certificate[] second) {
+        X509Certificate[] merged = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, merged, first.length, second.length);
+        return merged;
     }
 
     private PrivateKey forwardProxyPrivateKey() {


### PR DESCRIPTION
Hi,

This PR adds the JVM trust store to the MockServer client SSL context when configured to do so (e.g. `-Dmockserver.useJvmTrustCertificates="true"`).
This way one can avoid creating custom certificate chain file by using `mockserver.tlsMutualAuthenticationCertificateChain` when the certificates are already in the JVM trust store.

**Important note**
I'm unable to properly verify and run tests due to the following issue https://github.com/mock-server/mockserver/issues/1064 (master is broken).