### PR TITLE
Update configuring_sut.html

### DIFF
--- a/jekyll-www.mock-server.com/proxy/configuring_sut.html
+++ b/jekyll-www.mock-server.com/proxy/configuring_sut.html
@@ -26,7 +26,7 @@ sitemap:
     </li>
     <li><a href="#web_secure_web_proxy"><strong>Secure Web Proxy</strong></a> (i.e. HTTPS tunneling proxying)
         <ul>
-            <li>requests are forwarded using a CONNECT request that setups an HTTP tunnel</li>
+            <li>requests are forwarded using a CONNECT request that sets up an HTTP tunnel</li>
             <li>an SSL certificate is auto-generated allowing encrypted HTTPS traffic to be recorded transparently</li>
         </ul>
     </li>


### PR DESCRIPTION
Fixed 'setups' to 'sets up' as 'setups' is barely as word as 'set-ups'; and means something else then anyway.  In short, 'setup' != 'set up'.