### PR TITLE
fix flaky in JsonBodySerializerTest

### DIFF
--- a/mockserver-core/src/test/java/org/mockserver/serialization/serializers/body/JsonBodySerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/serializers/body/JsonBodySerializerTest.java
@@ -9,7 +9,7 @@ import org.mockserver.matchers.MatchType;
 import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static org.mockserver.model.JsonBody.json;
 import static org.mockserver.model.Not.not;
 
@@ -38,8 +38,10 @@ public class JsonBodySerializerTest {
 
     @Test
     public void shouldSerializeJsonBodyAsObject() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper().writeValueAsString(json(new TestObject())),
-                is("{\"type\":\"JSON\",\"json\":{\"fieldOne\":\"valueOne\",\"fieldTwo\":\"valueTwo\"}}"));
+        String actual = ObjectMapperFactory.createObjectMapper().writeValueAsString(json(new TestObject()));
+        String expectedCase1 = "{\"type\":\"JSON\",\"json\":{\"fieldOne\":\"valueOne\",\"fieldTwo\":\"valueTwo\"}}";
+        String expectedCase2 = "{\"type\":\"JSON\",\"json\":{\"fieldTwo\":\"valueTwo\",\"fieldOne\":\"valueOne\"}}";
+        assertTrue(actual.equals(expectedCase1) || actual.equals(expectedCase2));
     }
 
     @Test


### PR DESCRIPTION
org.mockserver.serialization.serializers.body.JsonBodySerializerTest.shouldSerializeJsonBodyAsObject is flaky due to the getDeclaredFields() non-deterministic  [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--), which is used by writeValueAsString(). So for this test case, it would be have two different answers, I changed the check statement so that either one of them will pass the test, which eliminates the flakiness.