### PR TITLE
Fix flaky in HttpResponseSerializerTest and HttpResponseDTOSerializerTest

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/serialization/ObjectMapperFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/ObjectMapperFactory.java
@@ -130,7 +130,7 @@ public class ObjectMapperFactory {
 
     private static ObjectMapper buildObjectMapperWithDeserializerAndSerializers(List<JsonDeserializer> replacementJsonDeserializers, List<JsonSerializer> replacementJsonSerializers) {
         ObjectMapper objectMapper = buildObjectMapperWithoutDeserializerAndSerializers();
-
+        objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY,true);
         // register our own module with our serializers and deserializers
         SimpleModule module = new SimpleModule();
         addDeserializers(module, replacementJsonDeserializers.toArray(new JsonDeserializer[0]));

--- a/mockserver-core/src/main/java/org/mockserver/serialization/ObjectMapperFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/serialization/ObjectMapperFactory.java
@@ -130,7 +130,7 @@ public class ObjectMapperFactory {
 
     private static ObjectMapper buildObjectMapperWithDeserializerAndSerializers(List<JsonDeserializer> replacementJsonDeserializers, List<JsonSerializer> replacementJsonSerializers) {
         ObjectMapper objectMapper = buildObjectMapperWithoutDeserializerAndSerializers();
-        objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY,true);
+        objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
         // register our own module with our serializers and deserializers
         SimpleModule module = new SimpleModule();
         addDeserializers(module, replacementJsonDeserializers.toArray(new JsonDeserializer[0]));

--- a/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializerTest.java
@@ -68,16 +68,16 @@ public class HttpResponseDTOSerializerTest {
                 "    \"value\" : 1" + NEW_LINE +
                 "  }," + NEW_LINE +
                 "  \"connectionOptions\" : {" + NEW_LINE +
-                "    \"suppressContentLengthHeader\" : true," + NEW_LINE +
-                "    \"contentLengthHeaderOverride\" : 50," + NEW_LINE +
-                "    \"suppressConnectionHeader\" : true," + NEW_LINE +
                 "    \"chunkSize\" : 100," + NEW_LINE +
-                "    \"keepAliveOverride\" : true," + NEW_LINE +
                 "    \"closeSocket\" : true," + NEW_LINE +
                 "    \"closeSocketDelay\" : {" + NEW_LINE +
                 "      \"timeUnit\" : \"MILLISECONDS\"," + NEW_LINE +
                 "      \"value\" : 100" + NEW_LINE +
-                "    }" + NEW_LINE +
+                "    }," + NEW_LINE +
+                "    \"contentLengthHeaderOverride\" : 50," + NEW_LINE +
+                "    \"keepAliveOverride\" : true," + NEW_LINE +
+                "    \"suppressConnectionHeader\" : true," + NEW_LINE +
+                "    \"suppressContentLengthHeader\" : true" + NEW_LINE +
                 "  }" + NEW_LINE +
                 "}"));
     }

--- a/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseSerializerTest.java
@@ -1,6 +1,11 @@
 package org.mockserver.serialization.serializers.response;
 
+import com.fasterxml.jackson.core.FormatSchema;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 import org.mockserver.model.ConnectionOptions;
 import org.mockserver.model.Cookie;
@@ -28,7 +33,8 @@ public class HttpResponseSerializerTest {
 
     @Test
     public void shouldReturnFormattedResponseWithAllFieldsSet() throws JsonProcessingException {
-        assertThat(ObjectMapperFactory.createObjectMapper(true).writeValueAsString(
+        assertThat(ObjectMapperFactory.createObjectMapper(true)
+                .writeValueAsString(
             response()
                 .withStatusCode(302)
                 .withReasonPhrase("randomReason")
@@ -62,16 +68,16 @@ public class HttpResponseSerializerTest {
                 "    \"value\" : 1" + NEW_LINE +
                 "  }," + NEW_LINE +
                 "  \"connectionOptions\" : {" + NEW_LINE +
-                "    \"suppressContentLengthHeader\" : true," + NEW_LINE +
-                "    \"contentLengthHeaderOverride\" : 50," + NEW_LINE +
-                "    \"suppressConnectionHeader\" : true," + NEW_LINE +
                 "    \"chunkSize\" : 100," + NEW_LINE +
-                "    \"keepAliveOverride\" : true," + NEW_LINE +
                 "    \"closeSocket\" : true," + NEW_LINE +
                 "    \"closeSocketDelay\" : {" + NEW_LINE +
                 "      \"timeUnit\" : \"MILLISECONDS\"," + NEW_LINE +
                 "      \"value\" : 100" + NEW_LINE +
-                "    }" + NEW_LINE +
+                "    }," + NEW_LINE +
+                "    \"contentLengthHeaderOverride\" : 50," + NEW_LINE +
+                "    \"keepAliveOverride\" : true," + NEW_LINE +
+                "    \"suppressConnectionHeader\" : true," + NEW_LINE +
+                "    \"suppressContentLengthHeader\" : true" + NEW_LINE +
                 "  }" + NEW_LINE +
                 "}"));
     }

--- a/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseSerializerTest.java
@@ -1,11 +1,6 @@
 package org.mockserver.serialization.serializers.response;
 
-import com.fasterxml.jackson.core.FormatSchema;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import org.junit.Test;
 import org.mockserver.model.ConnectionOptions;
 import org.mockserver.model.Cookie;


### PR DESCRIPTION
org.mockserver.serialization.serializers.response.HttpResponseSerializerTest.shouldReturnFormattedResponseWithAllFieldsSet is flaky, which is the same reason with [1088](https://github.com/mock-server/mockserver/pull/1088). There is another test org.mockserver.serialization.serializers.response.HttpResponseDTOSerializerTest.shouldReturnFormattedResponseWithAllFieldsSet is also flaky, and could be solve by the same change.