### PR TITLE
Fixed the flaky test method, shouldSerializeCompleteResquest, in WebSocketMessageSerializerTest

### DIFF
--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -12,6 +12,7 @@ import org.mockserver.serialization.model.*;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.Cookie.cookie;
 import static org.mockserver.model.Delay.minutes;

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -12,6 +12,7 @@ import org.mockserver.serialization.model.*;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.Cookie.cookie;
 import static org.mockserver.model.Delay.minutes;
@@ -29,189 +30,147 @@ public class WebSocketMessageSerializerTest {
     @Test
     public void shouldDeserializeCompleteResponse() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"name\\\" : \\\"someHeaderName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"timeUnit\\\" : \\\"SECONDS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : 5" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}";
+        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE
+                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"statusCode\\\" : 123,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : [ {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"name\\\" : \\\"someHeaderName\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ],"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"SECONDS\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 5"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
+                + NEW_LINE + "}";
 
         // when
         Object httpResponse = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpResponseDTO()
-            .setStatusCode(123)
-            .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-            .setHeaders(new Headers().withEntries(
-                header("someHeaderName", "someHeaderValue")
-            ))
-            .setCookies(new Cookies().withEntries(
-                cookie("someCookieName", "someCookieValue")
-            ))
-            .setDelay(new DelayDTO(seconds(5)))
-            .buildObject(), httpResponse);
+        assertEquals(new HttpResponseDTO().setStatusCode(123)
+                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
+                .setDelay(new DelayDTO(seconds(5))).buildObject(), httpResponse);
     }
 
     @Test
     public void shouldSerializeCompleteResponse() throws IOException {
         // when
-        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
-            new HttpResponseDTO()
-                .setStatusCode(123)
-                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(
-                    header("someHeaderName", "someHeaderValue")
-                ))
-                .setCookies(new Cookies().withEntries(
-                    cookie("someCookieName", "someCookieValue")
-                ))
-                .setDelay(new DelayDTO(minutes(1)))
-                .buildObject()
-        );
+        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpResponseDTO()
+                .setStatusCode(123).setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
+                .setDelay(new DelayDTO(minutes(1))).buildObject());
 
         // then
-        assertEquals("{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : 1" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}", jsonHttpResponse);
+        assertTrue(jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
+                + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
+                + NEW_LINE + "}")
+                || jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
+                        + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1,"
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\""
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "}\"" + NEW_LINE + "}"));
     }
 
     @Test
     public void shouldDeserializeCompleteRequest() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}";
+        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
+                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}";
 
         // when
         Object httpRequest = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpRequestDTO()
-            .setMethod(string("someMethod"))
-            .setPath(string("somePath"))
-            .setQueryStringParameters(new Parameters().withEntries(
-                param("queryParameterName", "queryParameterValue")
-            ))
-            .setBody(BodyDTO.createDTO(exact("somebody")))
-            .setHeaders(new Headers().withEntries(
-                header("someHeaderName", "someHeaderValue")
-            ))
-            .setCookies(new Cookies().withEntries(
-                cookie("someCookieName", "someCookieValue")
-            ))
-            .setSecure(true)
-            .setKeepAlive(false)
-            .setSocketAddress(new SocketAddressDTO(
-                new SocketAddress()
-                    .withHost("someHost")
-                    .withPort(1234)
-                    .withScheme(SocketAddress.Scheme.HTTPS)
-            ))
-            .buildObject(), httpRequest);
+        assertEquals(new HttpRequestDTO().setMethod(string("someMethod")).setPath(string("somePath"))
+                .setQueryStringParameters(
+                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
+                .setBody(BodyDTO.createDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
+                .setKeepAlive(false)
+                .setSocketAddress(new SocketAddressDTO(
+                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
+                .buildObject(), httpRequest);
     }
 
     @Test
     public void shouldSerializeCompleteRequest() throws IOException {
         // when
-        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
-            new HttpRequestDTO()
-                .setMethod(string("someMethod"))
-                .setPath(string("somePath"))
-                .setQueryStringParameters(new Parameters().withEntries(
-                    param("queryParameterName", "queryParameterValue")
-                ))
+        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpRequestDTO()
+                .setMethod(string("someMethod")).setPath(string("somePath"))
+                .setQueryStringParameters(
+                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
                 .setBody(BodyDTO.createDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(
-                    header("someHeaderName", "someHeaderValue")
-                ))
-                .setCookies(new Cookies().withEntries(
-                    cookie("someCookieName", "someCookieValue")
-                ))
-                .setSecure(true)
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
                 .setKeepAlive(false)
                 .setSocketAddress(new SocketAddressDTO(
-                    new SocketAddress()
-                        .withHost("someHost")
-                        .withPort(1234)
-                        .withScheme(SocketAddress.Scheme.HTTPS)
-                ))
-                .buildObject()
-        );
+                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
+                .buildObject());
 
         // then
-        assertEquals("{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}", jsonHttpRequest);
+        assertEquals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
+                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}",
+                jsonHttpRequest);
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -12,7 +12,6 @@ import org.mockserver.serialization.model.*;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.Cookie.cookie;
 import static org.mockserver.model.Delay.minutes;
@@ -85,8 +84,7 @@ public class WebSocketMessageSerializerTest {
         );
 
         // then
-        assertTrue(jsonHttpResponse.equals(
-            "{" + NEW_LINE +
+        assertEquals("{" + NEW_LINE +
             "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
             "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
             "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
@@ -102,26 +100,7 @@ public class WebSocketMessageSerializerTest {
             "    \\\"value\\\" : 1" + StringEscapeUtils.escapeJava(NEW_LINE) +
             "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
             "}\"" + NEW_LINE +
-            "}"
-        ) || jsonHttpResponse.equals(
-            "{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : 1," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}"
-        ));
+            "}", jsonHttpResponse);
     }
 
     @Test

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -188,30 +188,61 @@ public class WebSocketMessageSerializerTest {
         );
 
         // then
-        assertEquals("{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}", jsonHttpRequest);
+        String socketAddressString1 = "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String socketAddressString2 = "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"scheme\\\" : \\\"HTTPS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"port\\\" : 1234" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String socketAddressString3 = "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String socketAddressString4 = "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"scheme\\\" : \\\"HTTPS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"host\\\" : \\\"someHost\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String socketAddressString5 = "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"scheme\\\" : \\\"HTTPS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"port\\\" : 1234" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String socketAddressString6 = "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"scheme\\\" : \\\"HTTPS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"host\\\" : \\\"someHost\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String valueStringBeforeSocketAddress = "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE);
+        String valueStringAfterSocketAddress = "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+        "}\"";
+
+        assertTrue(jsonHttpRequest.contains("type\" : \"org.mockserver.model.HttpRequest\"") && (
+            jsonHttpRequest.contains(valueStringBeforeSocketAddress + socketAddressString1 + valueStringAfterSocketAddress) ||
+            jsonHttpRequest.contains(valueStringBeforeSocketAddress + socketAddressString2 + valueStringAfterSocketAddress) ||
+            jsonHttpRequest.contains(valueStringBeforeSocketAddress + socketAddressString3 + valueStringAfterSocketAddress) ||
+            jsonHttpRequest.contains(valueStringBeforeSocketAddress + socketAddressString4 + valueStringAfterSocketAddress) ||
+            jsonHttpRequest.contains(valueStringBeforeSocketAddress + socketAddressString5 + valueStringAfterSocketAddress) ||
+            jsonHttpRequest.contains(valueStringBeforeSocketAddress + socketAddressString6 + valueStringAfterSocketAddress)
+        ));
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -30,147 +30,209 @@ public class WebSocketMessageSerializerTest {
     @Test
     public void shouldDeserializeCompleteResponse() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE
-                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"statusCode\\\" : 123,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : [ {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"name\\\" : \\\"someHeaderName\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ],"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"SECONDS\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 5"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
-                + NEW_LINE + "}";
+        String requestBytes = "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"name\\\" : \\\"someHeaderName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"timeUnit\\\" : \\\"SECONDS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : 5" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}";
 
         // when
         Object httpResponse = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpResponseDTO().setStatusCode(123)
-                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
-                .setDelay(new DelayDTO(seconds(5))).buildObject(), httpResponse);
+        assertEquals(new HttpResponseDTO()
+            .setStatusCode(123)
+            .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+            .setHeaders(new Headers().withEntries(
+                header("someHeaderName", "someHeaderValue")
+            ))
+            .setCookies(new Cookies().withEntries(
+                cookie("someCookieName", "someCookieValue")
+            ))
+            .setDelay(new DelayDTO(seconds(5)))
+            .buildObject(), httpResponse);
     }
 
     @Test
     public void shouldSerializeCompleteResponse() throws IOException {
         // when
-        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpResponseDTO()
-                .setStatusCode(123).setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
-                .setDelay(new DelayDTO(minutes(1))).buildObject());
+        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
+            new HttpResponseDTO()
+                .setStatusCode(123)
+                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(
+                    header("someHeaderName", "someHeaderValue")
+                ))
+                .setCookies(new Cookies().withEntries(
+                    cookie("someCookieName", "someCookieValue")
+                ))
+                .setDelay(new DelayDTO(minutes(1)))
+                .buildObject()
+        );
 
         // then
-        assertTrue(jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
-                + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
-                + NEW_LINE + "}")
-                || jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
-                        + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1,"
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\""
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "}\"" + NEW_LINE + "}"));
+        assertTrue(jsonHttpResponse.equals(
+            "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : 1" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}"
+        ) || jsonHttpResponse.equals(
+            "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : 1," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}"
+        ));
     }
 
     @Test
     public void shouldDeserializeCompleteRequest() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
-                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}";
+        String requestBytes = "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}";
 
         // when
         Object httpRequest = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpRequestDTO().setMethod(string("someMethod")).setPath(string("somePath"))
-                .setQueryStringParameters(
-                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
-                .setBody(BodyDTO.createDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
-                .setKeepAlive(false)
-                .setSocketAddress(new SocketAddressDTO(
-                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
-                .buildObject(), httpRequest);
+        assertEquals(new HttpRequestDTO()
+            .setMethod(string("someMethod"))
+            .setPath(string("somePath"))
+            .setQueryStringParameters(new Parameters().withEntries(
+                param("queryParameterName", "queryParameterValue")
+            ))
+            .setBody(BodyDTO.createDTO(exact("somebody")))
+            .setHeaders(new Headers().withEntries(
+                header("someHeaderName", "someHeaderValue")
+            ))
+            .setCookies(new Cookies().withEntries(
+                cookie("someCookieName", "someCookieValue")
+            ))
+            .setSecure(true)
+            .setKeepAlive(false)
+            .setSocketAddress(new SocketAddressDTO(
+                new SocketAddress()
+                    .withHost("someHost")
+                    .withPort(1234)
+                    .withScheme(SocketAddress.Scheme.HTTPS)
+            ))
+            .buildObject(), httpRequest);
     }
 
     @Test
     public void shouldSerializeCompleteRequest() throws IOException {
         // when
-        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpRequestDTO()
-                .setMethod(string("someMethod")).setPath(string("somePath"))
-                .setQueryStringParameters(
-                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
+        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
+            new HttpRequestDTO()
+                .setMethod(string("someMethod"))
+                .setPath(string("somePath"))
+                .setQueryStringParameters(new Parameters().withEntries(
+                    param("queryParameterName", "queryParameterValue")
+                ))
                 .setBody(BodyDTO.createDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
+                .setHeaders(new Headers().withEntries(
+                    header("someHeaderName", "someHeaderValue")
+                ))
+                .setCookies(new Cookies().withEntries(
+                    cookie("someCookieName", "someCookieValue")
+                ))
+                .setSecure(true)
                 .setKeepAlive(false)
                 .setSocketAddress(new SocketAddressDTO(
-                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
-                .buildObject());
+                    new SocketAddress()
+                        .withHost("someHost")
+                        .withPort(1234)
+                        .withScheme(SocketAddress.Scheme.HTTPS)
+                ))
+                .buildObject()
+        );
 
         // then
-        assertEquals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
-                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}",
-                jsonHttpRequest);
+        assertEquals("{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}", jsonHttpRequest);
     }
 
 }


### PR DESCRIPTION
This flaky test is detected by using NonDex, a flaky test detection tool. The test is fixed by changing the assertion method from assertEquals to assertTrue which includes multiple possible strings.

With the original test method, it was found in the serialized string of http request that the orders of some fields is non-deterministic. One non-deterministic order is the order of "type" and "value". The other is the order of the three fields, "host", "port", and "scheme", of the "socketAddress" field inside "value". The assertion method is changed from assertEquals to assertTrue. Inside the assertion, it assert that the serialized string contains the "type" field and that serialized string contains one of the six possible "value" strings. For the "value" strings, only the "socketAddress" field is different.