### PR TITLE
Fixed the flaky test method, shouldPersistExpectationsToJsonOnRemove, in ExpectationFileSystemPersistenceTest

### DIFF
--- a/mockserver-core/src/test/java/org/mockserver/persistence/ExpectationFileSystemPersistenceTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/persistence/ExpectationFileSystemPersistenceTest.java
@@ -13,6 +13,7 @@ import org.mockserver.scheduler.Scheduler;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.*;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.CoreMatchers.is;
@@ -177,38 +178,7 @@ public class ExpectationFileSystemPersistenceTest {
             MILLISECONDS.sleep(1500);
 
             // then
-            String expectedFileContents = "[ {" + NEW_LINE +
-                "  \"id\" : \"one\"," + NEW_LINE +
-                "  \"priority\" : 0," + NEW_LINE +
-                "  \"httpRequest\" : {" + NEW_LINE +
-                "    \"path\" : \"/simpleFirst\"" + NEW_LINE +
-                "  }," + NEW_LINE +
-                "  \"times\" : {" + NEW_LINE +
-                "    \"unlimited\" : true" + NEW_LINE +
-                "  }," + NEW_LINE +
-                "  \"timeToLive\" : {" + NEW_LINE +
-                "    \"unlimited\" : true" + NEW_LINE +
-                "  }," + NEW_LINE +
-                "  \"httpResponse\" : {" + NEW_LINE +
-                "    \"body\" : \"some first response\"" + NEW_LINE +
-                "  }" + NEW_LINE +
-                "}, {" + NEW_LINE +
-                "  \"id\" : \"three\"," + NEW_LINE +
-                "  \"priority\" : 0," + NEW_LINE +
-                "  \"httpRequest\" : {" + NEW_LINE +
-                "    \"path\" : \"/simpleThird\"" + NEW_LINE +
-                "  }," + NEW_LINE +
-                "  \"times\" : {" + NEW_LINE +
-                "    \"unlimited\" : true" + NEW_LINE +
-                "  }," + NEW_LINE +
-                "  \"timeToLive\" : {" + NEW_LINE +
-                "    \"unlimited\" : true" + NEW_LINE +
-                "  }," + NEW_LINE +
-                "  \"httpResponse\" : {" + NEW_LINE +
-                "    \"body\" : \"some third response\"" + NEW_LINE +
-                "  }" + NEW_LINE +
-                "} ]";
-            assertThat(persistedExpectations.getAbsolutePath() + " does not match expected content", new String(Files.readAllBytes(persistedExpectations.toPath()), StandardCharsets.UTF_8), is(expectedFileContents));
+            assertThat(persistedExpectations.getAbsolutePath() + " does not match expected content", match(new String(Files.readAllBytes(persistedExpectations.toPath()))));
         } finally {
             ConfigurationProperties.persistedExpectationsPath(persistedExpectationsPath);
             ConfigurationProperties.persistExpectations(false);
@@ -216,6 +186,99 @@ public class ExpectationFileSystemPersistenceTest {
                 expectationFileSystemPersistence.stop();
             }
         }
+    }
+
+    private boolean match(String actualFileContent) {
+        String prefix = "[ {" + NEW_LINE;
+        String middle = "}, {" + NEW_LINE;
+        String suffix = "} ]";
+
+        String id1 = "  \"id\" : \"one\"";
+        String priority1 = "  \"priority\" : 0";
+        String httpRequest1 = "  \"httpRequest\" : {" + NEW_LINE +
+        "    \"path\" : \"/simpleFirst\"" + NEW_LINE +
+        "  }";
+        String times1 = "  \"times\" : {" + NEW_LINE +
+        "    \"unlimited\" : true" + NEW_LINE +
+        "  }";
+        String timeToLive1 = "  \"timeToLive\" : {" + NEW_LINE +
+        "    \"unlimited\" : true" + NEW_LINE +
+        "  }";
+        String httpResponse1 = "  \"httpResponse\" : {" + NEW_LINE +
+        "    \"body\" : \"some first response\"" + NEW_LINE +
+        "  }";
+
+        String id3 = "  \"id\" : \"three\"";
+        String priority3 = "  \"priority\" : 0";
+        String httpRequest3 = "  \"httpRequest\" : {" + NEW_LINE +
+        "    \"path\" : \"/simpleThird\"" + NEW_LINE +
+        "  }";
+        String times3 = "  \"times\" : {" + NEW_LINE +
+        "    \"unlimited\" : true" + NEW_LINE +
+        "  }";
+        String timeToLive3 = "  \"timeToLive\" : {" + NEW_LINE +
+        "    \"unlimited\" : true" + NEW_LINE +
+        "  }";
+        String httpResponse3 = "  \"httpResponse\" : {" + NEW_LINE +
+        "    \"body\" : \"some third response\"" + NEW_LINE +
+        "  }";
+
+        String[] arr1 = {id1, priority1, httpRequest1, times1, timeToLive1, httpResponse1};
+        String[] arr3 = {id3, priority3, httpRequest3, times3, timeToLive3, httpResponse3};
+        Set<String> expectedFileContents1 = getAllPossibleFileContents(arr1);
+        Set<String> expectedFileContents3 = getAllPossibleFileContents(arr3);
+        for (String content1 : expectedFileContents1) {
+            for (String content3 : expectedFileContents3) {
+                if (actualFileContent.equals(prefix + content1 + middle + content3 + suffix)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Set<String> getAllPossibleFileContents(String[] arr) {
+        List<List<String>> allPermutations = new ArrayList<>();
+        List<String> currPermutation = new ArrayList<>();
+        dfs(arr, allPermutations, currPermutation, 0);
+        return buildAllPossibleFileContents(allPermutations);
+    }
+
+    private Set<String> buildAllPossibleFileContents(List<List<String>> allPermutations) {
+        Set<String> set = new HashSet<>();
+        for (List<String> list : allPermutations) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < list.size(); i++) {
+                sb.append(list.get(i));
+                if (i != list.size() - 1) {
+                    sb.append("," + NEW_LINE);
+                } else {
+                    sb.append(NEW_LINE);
+                }
+            }
+            set.add(sb.toString());
+        }
+        return set;
+    }
+
+    private void dfs(String[] arr, List<List<String>> res, List<String> list, int index) {
+        if (index == arr.length) {
+            res.add(new ArrayList<>(list));
+            return;
+        }
+        for (int i = index; i < arr.length; i++) {
+            swap(arr, index, i);
+            list.add(arr[index]);
+            dfs(arr, res, list, index + 1);
+            list.remove(list.size() - 1);
+            swap(arr, index, i);
+        }
+    }
+
+    private void swap(String[] arr, int i, int j) {
+        String tmp = arr[i];
+        arr[i] = arr[j];
+        arr[j] = tmp;
     }
 
     @Test

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -12,6 +12,7 @@ import org.mockserver.serialization.model.*;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.Cookie.cookie;
 import static org.mockserver.model.Delay.minutes;
@@ -29,189 +30,147 @@ public class WebSocketMessageSerializerTest {
     @Test
     public void shouldDeserializeCompleteResponse() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"name\\\" : \\\"someHeaderName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"timeUnit\\\" : \\\"SECONDS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : 5" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}";
+        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE
+                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"statusCode\\\" : 123,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : [ {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"name\\\" : \\\"someHeaderName\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ],"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"SECONDS\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 5"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
+                + NEW_LINE + "}";
 
         // when
         Object httpResponse = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpResponseDTO()
-            .setStatusCode(123)
-            .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-            .setHeaders(new Headers().withEntries(
-                header("someHeaderName", "someHeaderValue")
-            ))
-            .setCookies(new Cookies().withEntries(
-                cookie("someCookieName", "someCookieValue")
-            ))
-            .setDelay(new DelayDTO(seconds(5)))
-            .buildObject(), httpResponse);
+        assertEquals(new HttpResponseDTO().setStatusCode(123)
+                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
+                .setDelay(new DelayDTO(seconds(5))).buildObject(), httpResponse);
     }
 
     @Test
     public void shouldSerializeCompleteResponse() throws IOException {
         // when
-        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
-            new HttpResponseDTO()
-                .setStatusCode(123)
-                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(
-                    header("someHeaderName", "someHeaderValue")
-                ))
-                .setCookies(new Cookies().withEntries(
-                    cookie("someCookieName", "someCookieValue")
-                ))
-                .setDelay(new DelayDTO(minutes(1)))
-                .buildObject()
-        );
+        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpResponseDTO()
+                .setStatusCode(123).setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
+                .setDelay(new DelayDTO(minutes(1))).buildObject());
 
         // then
-        assertEquals("{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : 1" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}", jsonHttpResponse);
+        assertTrue(jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
+                + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
+                + NEW_LINE + "}")
+                || jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
+                        + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1,"
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\""
+                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE)
+                        + "}\"" + NEW_LINE + "}"));
     }
 
     @Test
     public void shouldDeserializeCompleteRequest() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}";
+        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
+                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}";
 
         // when
         Object httpRequest = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpRequestDTO()
-            .setMethod(string("someMethod"))
-            .setPath(string("somePath"))
-            .setQueryStringParameters(new Parameters().withEntries(
-                param("queryParameterName", "queryParameterValue")
-            ))
-            .setBody(BodyDTO.createDTO(exact("somebody")))
-            .setHeaders(new Headers().withEntries(
-                header("someHeaderName", "someHeaderValue")
-            ))
-            .setCookies(new Cookies().withEntries(
-                cookie("someCookieName", "someCookieValue")
-            ))
-            .setSecure(true)
-            .setKeepAlive(false)
-            .setSocketAddress(new SocketAddressDTO(
-                new SocketAddress()
-                    .withHost("someHost")
-                    .withPort(1234)
-                    .withScheme(SocketAddress.Scheme.HTTPS)
-            ))
-            .buildObject(), httpRequest);
+        assertEquals(new HttpRequestDTO().setMethod(string("someMethod")).setPath(string("somePath"))
+                .setQueryStringParameters(
+                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
+                .setBody(BodyDTO.createDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
+                .setKeepAlive(false)
+                .setSocketAddress(new SocketAddressDTO(
+                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
+                .buildObject(), httpRequest);
     }
 
     @Test
     public void shouldSerializeCompleteRequest() throws IOException {
         // when
-        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
-            new HttpRequestDTO()
-                .setMethod(string("someMethod"))
-                .setPath(string("somePath"))
-                .setQueryStringParameters(new Parameters().withEntries(
-                    param("queryParameterName", "queryParameterValue")
-                ))
+        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpRequestDTO()
+                .setMethod(string("someMethod")).setPath(string("somePath"))
+                .setQueryStringParameters(
+                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
                 .setBody(BodyDTO.createDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(
-                    header("someHeaderName", "someHeaderValue")
-                ))
-                .setCookies(new Cookies().withEntries(
-                    cookie("someCookieName", "someCookieValue")
-                ))
-                .setSecure(true)
+                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
+                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
                 .setKeepAlive(false)
                 .setSocketAddress(new SocketAddressDTO(
-                    new SocketAddress()
-                        .withHost("someHost")
-                        .withPort(1234)
-                        .withScheme(SocketAddress.Scheme.HTTPS)
-                ))
-                .buildObject()
-        );
+                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
+                .buildObject());
 
         // then
-        assertEquals("{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}", jsonHttpRequest);
+        assertEquals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
+                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
+                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
+                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}",
+                jsonHttpRequest);
     }
 
 }

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -12,7 +12,6 @@ import org.mockserver.serialization.model.*;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.model.Cookie.cookie;
 import static org.mockserver.model.Delay.minutes;
@@ -85,8 +84,7 @@ public class WebSocketMessageSerializerTest {
         );
 
         // then
-        assertTrue(jsonHttpResponse.equals(
-            "{" + NEW_LINE +
+        assertEquals("{" + NEW_LINE +
             "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
             "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
             "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
@@ -102,26 +100,7 @@ public class WebSocketMessageSerializerTest {
             "    \\\"value\\\" : 1" + StringEscapeUtils.escapeJava(NEW_LINE) +
             "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
             "}\"" + NEW_LINE +
-            "}"
-        ) || jsonHttpResponse.equals(
-            "{" + NEW_LINE +
-            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
-            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"value\\\" : 1," + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
-            "}\"" + NEW_LINE +
-            "}"
-        ));
+            "}", jsonHttpResponse);
     }
 
     @Test

--- a/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/serialization/WebSocketMessageSerializerTest.java
@@ -30,147 +30,209 @@ public class WebSocketMessageSerializerTest {
     @Test
     public void shouldDeserializeCompleteResponse() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE
-                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"statusCode\\\" : 123,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : [ {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"name\\\" : \\\"someHeaderName\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "  } ],"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"SECONDS\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 5"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
-                + NEW_LINE + "}";
+        String requestBytes = "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"name\\\" : \\\"someHeaderName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"values\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : [ {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"name\\\" : \\\"someCookieName\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  } ]," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"timeUnit\\\" : \\\"SECONDS\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : 5" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}";
 
         // when
         Object httpResponse = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpResponseDTO().setStatusCode(123)
-                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
-                .setDelay(new DelayDTO(seconds(5))).buildObject(), httpResponse);
+        assertEquals(new HttpResponseDTO()
+            .setStatusCode(123)
+            .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+            .setHeaders(new Headers().withEntries(
+                header("someHeaderName", "someHeaderValue")
+            ))
+            .setCookies(new Cookies().withEntries(
+                cookie("someCookieName", "someCookieValue")
+            ))
+            .setDelay(new DelayDTO(seconds(5)))
+            .buildObject(), httpResponse);
     }
 
     @Test
     public void shouldSerializeCompleteResponse() throws IOException {
         // when
-        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpResponseDTO()
-                .setStatusCode(123).setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue")))
-                .setDelay(new DelayDTO(minutes(1))).buildObject());
+        String jsonHttpResponse = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
+            new HttpResponseDTO()
+                .setStatusCode(123)
+                .setBody(BodyWithContentTypeDTO.createWithContentTypeDTO(exact("somebody")))
+                .setHeaders(new Headers().withEntries(
+                    header("someHeaderName", "someHeaderValue")
+                ))
+                .setCookies(new Cookies().withEntries(
+                    cookie("someCookieName", "someCookieValue")
+                ))
+                .setDelay(new DelayDTO(minutes(1)))
+                .buildObject()
+        );
 
         // then
-        assertTrue(jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
-                + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"headers\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"body\\\" : \\\"somebody\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"delay\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\""
-                + NEW_LINE + "}")
-                || jsonHttpResponse.equals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpResponse\","
-                        + NEW_LINE + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]"
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"value\\\" : 1,"
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"timeUnit\\\" : \\\"MINUTES\\\""
-                        + StringEscapeUtils.escapeJava(NEW_LINE) + "  }" + StringEscapeUtils.escapeJava(NEW_LINE)
-                        + "}\"" + NEW_LINE + "}"));
+        assertTrue(jsonHttpResponse.equals(
+            "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : 1" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}"
+        ) || jsonHttpResponse.equals(
+            "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpResponse\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"statusCode\\\" : 123," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"delay\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"value\\\" : 1," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"timeUnit\\\" : \\\"MINUTES\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}"
+        ));
     }
 
     @Test
     public void shouldDeserializeCompleteRequest() throws IOException, ClassNotFoundException {
         // given
-        String requestBytes = "{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
-                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}";
+        String requestBytes = "{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}";
 
         // when
         Object httpRequest = new WebSocketMessageSerializer(new MockServerLogger()).deserialize(requestBytes);
 
         // then
-        assertEquals(new HttpRequestDTO().setMethod(string("someMethod")).setPath(string("somePath"))
-                .setQueryStringParameters(
-                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
-                .setBody(BodyDTO.createDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
-                .setKeepAlive(false)
-                .setSocketAddress(new SocketAddressDTO(
-                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
-                .buildObject(), httpRequest);
+        assertEquals(new HttpRequestDTO()
+            .setMethod(string("someMethod"))
+            .setPath(string("somePath"))
+            .setQueryStringParameters(new Parameters().withEntries(
+                param("queryParameterName", "queryParameterValue")
+            ))
+            .setBody(BodyDTO.createDTO(exact("somebody")))
+            .setHeaders(new Headers().withEntries(
+                header("someHeaderName", "someHeaderValue")
+            ))
+            .setCookies(new Cookies().withEntries(
+                cookie("someCookieName", "someCookieValue")
+            ))
+            .setSecure(true)
+            .setKeepAlive(false)
+            .setSocketAddress(new SocketAddressDTO(
+                new SocketAddress()
+                    .withHost("someHost")
+                    .withPort(1234)
+                    .withScheme(SocketAddress.Scheme.HTTPS)
+            ))
+            .buildObject(), httpRequest);
     }
 
     @Test
     public void shouldSerializeCompleteRequest() throws IOException {
         // when
-        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(new HttpRequestDTO()
-                .setMethod(string("someMethod")).setPath(string("somePath"))
-                .setQueryStringParameters(
-                        new Parameters().withEntries(param("queryParameterName", "queryParameterValue")))
+        String jsonHttpRequest = new WebSocketMessageSerializer(new MockServerLogger()).serialize(
+            new HttpRequestDTO()
+                .setMethod(string("someMethod"))
+                .setPath(string("somePath"))
+                .setQueryStringParameters(new Parameters().withEntries(
+                    param("queryParameterName", "queryParameterValue")
+                ))
                 .setBody(BodyDTO.createDTO(exact("somebody")))
-                .setHeaders(new Headers().withEntries(header("someHeaderName", "someHeaderValue")))
-                .setCookies(new Cookies().withEntries(cookie("someCookieName", "someCookieValue"))).setSecure(true)
+                .setHeaders(new Headers().withEntries(
+                    header("someHeaderName", "someHeaderValue")
+                ))
+                .setCookies(new Cookies().withEntries(
+                    cookie("someCookieName", "someCookieValue")
+                ))
+                .setSecure(true)
                 .setKeepAlive(false)
                 .setSocketAddress(new SocketAddressDTO(
-                        new SocketAddress().withHost("someHost").withPort(1234).withScheme(SocketAddress.Scheme.HTTPS)))
-                .buildObject());
+                    new SocketAddress()
+                        .withHost("someHost")
+                        .withPort(1234)
+                        .withScheme(SocketAddress.Scheme.HTTPS)
+                ))
+                .buildObject()
+        );
 
         // then
-        assertEquals("{" + NEW_LINE + "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE
-                + "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  }," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"cookies\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"someCookieName\\\" : \\\"someCookieValue\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"secure\\\" : true,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  \\\"socketAddress\\\" : {"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"host\\\" : \\\"someHost\\\","
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"port\\\" : 1234,"
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "    \\\"scheme\\\" : \\\"HTTPS\\\""
-                + StringEscapeUtils.escapeJava(NEW_LINE) + "  }," + StringEscapeUtils.escapeJava(NEW_LINE)
-                + "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) + "}\"" + NEW_LINE + "}",
-                jsonHttpRequest);
+        assertEquals("{" + NEW_LINE +
+            "  \"type\" : \"org.mockserver.model.HttpRequest\"," + NEW_LINE +
+            "  \"value\" : \"{" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"method\\\" : \\\"someMethod\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"path\\\" : \\\"somePath\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"queryStringParameters\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"queryParameterName\\\" : [ \\\"queryParameterValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"headers\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someHeaderName\\\" : [ \\\"someHeaderValue\\\" ]" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"cookies\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"someCookieName\\\" : \\\"someCookieValue\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"keepAlive\\\" : false," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"secure\\\" : true," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"socketAddress\\\" : {" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"host\\\" : \\\"someHost\\\"," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"port\\\" : 1234," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "    \\\"scheme\\\" : \\\"HTTPS\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  }," + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "  \\\"body\\\" : \\\"somebody\\\"" + StringEscapeUtils.escapeJava(NEW_LINE) +
+            "}\"" + NEW_LINE +
+            "}", jsonHttpRequest);
     }
 
 }


### PR DESCRIPTION
This flaky test is detected by using NonDex, a flaky test detection tool. The test was fixed by checking whether the actual file content contains all attributes.

With the original test method, it was found that the order of the attributes in the actual file contents are different from the expected file contents. To fix this flaky test, the method of depth-first search is used to find all possible orders of attributes and build all possible file contents. If the actual file contents is included in the set of all possible file contents, the test will pass.