### PR TITLE
Fix flaky test shouldMapHttpServletRequestToHttpRequest

### DIFF
--- a/mockserver-core/src/test/java/org/mockserver/mappers/HttpServletRequestToMockServerHttpRequestDecoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/HttpServletRequestToMockServerHttpRequestDecoderTest.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.HashSet;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertEquals;
@@ -46,10 +47,10 @@ public class HttpServletRequestToMockServerHttpRequestDecoderTest {
             new Parameter("bodyParameterNameOne", "bodyParameterValueOne_Two"),
             new Parameter("bodyParameterNameTwo", "bodyParameterValueTwo_One")
         ).toString(), httpRequest.getBody().toString());
-        assertEquals(Arrays.asList(
+        assertEquals(new HashSet<>(Arrays.asList(
             new Parameter("queryStringParameterNameOne", "queryStringParameterValueOne_One", "queryStringParameterValueOne_Two"),
             new Parameter("queryStringParameterNameTwo", "queryStringParameterValueTwo_One")
-        ), httpRequest.getQueryStringParameterList());
+        )), new HashSet<>(httpRequest.getQueryStringParameterList()));
         assertEquals(Lists.newArrayList(
             new Header("headerName1", "headerValue1_1", "headerValue1_2"),
             new Header("headerName2", "headerValue2"),


### PR DESCRIPTION
Hi! I'm Pengyue from the same testing research group at the University of Illinois which has previously made pull requests #932, #945, #949, #1089 etc. on flaky tests.

Thank you so much for the commit https://github.com/mock-server/mockserver/commit/ea5052d1dfd2e9edc4dbddcdebdaf0eb2acbfd98 which fixed most of the flaky tests in one go!

## Problem Description

The problem is a flaky test in the latest commit can be reproduced through the following procedures:

```
mvn clean
mvn -pl mockserver-core install -am -Dmaven.test.skip=true
mvn -pl mockserver-core edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.mockserver.mappers.HttpServletRequestToMockServerHttpRequestDecoderTest#shouldMapHttpServletRequestToHttpRequest -DnondexRuns=10
```

A failure occurred for that given test.

Through examination in combination with the help of [NonDex](https://github.com/TestingResearchIllinois/NonDex), its believed that the tool shuffled the list elements in the assertion at line 49 in the testing class `org.mockserver.mappers.HttpServletRequestToMockServerHttpRequestDecoderTest`.

## The Fix

Since the two elements in that particular assertion statement has different names, and there are only two elements, it is safe to convert them to `HashSet` and then compare, while not affecting any original objectives of the test case. It's a relatively simple change.

After this change was made, running the previous commands in the problem description section will always pass successfully without receive any failures.

Last but not least, please do leave a comment down below if you find anything problematic about this, or requires an improvement from me, thank you and hope to hear back from you soon :)