### PR TITLE
Don't use shaded dependencies by default

### DIFF
--- a/mockserver-examples/pom.xml
+++ b/mockserver-examples/pom.xml
@@ -86,12 +86,10 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mockserver-integration-testing/pom.xml
+++ b/mockserver-integration-testing/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mockserver-junit-jupiter/pom.xml
+++ b/mockserver-junit-jupiter/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mockserver-junit-rule/pom.xml
+++ b/mockserver-junit-rule/pom.xml
@@ -19,7 +19,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mockserver-proxy-war/pom.xml
+++ b/mockserver-proxy-war/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <classifier>shaded</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/mockserver-spring-test-listener/pom.xml
+++ b/mockserver-spring-test-listener/pom.xml
@@ -18,7 +18,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <classifier>shaded</classifier>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mockserver-war/pom.xml
+++ b/mockserver-war/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <classifier>shaded</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>mockserver-netty</artifactId>
-                <classifier>shaded</classifier>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -119,7 +118,6 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>mockserver-client-java</artifactId>
-                <classifier>shaded</classifier>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Shaded dependencies can still be used on an opt-in basis by specified
the shaded classifier.

Closes: https://github.com/mock-server/mockserver/issues/1244