### PR TITLE
Add Bodys From File for JSON

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/model/JsonBody.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/JsonBody.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Files;
 import org.mockserver.matchers.MatchType;
 import org.mockserver.serialization.ObjectMapperFactory;
+import org.apache.commons.lang3.StringUtils;
 
+import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Objects;
@@ -72,6 +75,18 @@ public class JsonBody extends BodyWithContentType<String> {
     }
 
     public static JsonBody json(String json, MediaType contentType, MatchType matchType) {
+        return new JsonBody(json, null, contentType, matchType);
+    }
+
+    public static JsonBody json(File file, MediaType contentType, MatchType matchType) {
+        String json = StringUtils.EMPTY;
+        if (file.exists()) {
+            try {
+                json = Files.asCharSource(file, Charset.defaultCharset()).read();
+            } catch (Exception ex) {
+                throw new RuntimeException("Error reading file at " + file.getAbsolutePath(), ex);
+            }
+        }
         return new JsonBody(json, null, contentType, matchType);
     }
 


### PR DESCRIPTION
Enabling to declare a file for the bodies of the request and/or response passing from this expectation:

```json
{
  "httpRequest": {
    "path": "/some/path/{cartId}/{maxItemCount}",
    "body": {
         "hello": "bye"
    }
  },
  "httpResponse": {
    "body": {
        "id": 0,
        "category": {
          "id": 0,
          "name": "string"
        },
        "name": "doggie",
        "photoUrls": [
          "string"
        ],
        "tags": [
          {
            "id": 0,
            "name": "string"
          }
        ],
        "status": "available"
     }    
  }
}
```
To this type of expectation:

```json
{
  "httpRequest": {
    "path": "/some/path/{cartId}/{maxItemCount}",
    "body": {
        "type" : "JSON",
        "jsonFile" : "/file/path/of/request_body.json.json",
        "contentType" : "application/json; charset=utf-8"
    }
  },
  "httpResponse": {
    "body": {
        "type" : "JSON",
        "jsonFile" : "/file/path/of/response_body.json.json",
        "contentType" : "application/json; charset=utf-8"
     }    
  }
}
```