### PR TITLE
fixes #1281 support for server urls in OpenAPI specification, by adding server url path as path prefix to operations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
--
+- support for server urls in OpenAPI specification, by adding server url path as path prefix to operations
 
 ### Changed
 -

--- a/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestsPropertiesMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/matchers/HttpRequestsPropertiesMatcherTest.java
@@ -6095,7 +6095,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6117,7 +6117,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets/12345")
+            .withPath("/v1/pets/12345")
             .withHeader("X-Request-ID", UUID.randomUUID().toString())
             .withHeader("Other-Header", UUID.randomUUID().toString());
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
@@ -6140,7 +6140,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6158,6 +6158,72 @@ public class HttpRequestsPropertiesMatcherTest {
         httpRequestsPropertiesMatcher.update(new Expectation(
             new OpenAPIDefinition()
                 .withSpecUrlOrPayload("org/mockserver/openapi/openapi_petstore_example.yaml")
+                .withOperationId("listPets")
+        ));
+        HttpRequest httpRequest = request()
+            .withMethod("GET")
+            .withPath("/v1/pets")
+            .withQueryStringParameter("limit", "10");
+        MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
+
+        // when
+        boolean matches = httpRequestsPropertiesMatcher.matches(context, httpRequest);
+
+        // then
+        thenMatchesEmptyFieldDifferences(context, matches, true);
+    }
+
+    @Test
+    public void shouldMatchSingleOperationInOpenAPIWithOperationServerYamlUrl() {
+        // given
+        HttpRequestsPropertiesMatcher httpRequestsPropertiesMatcher = new HttpRequestsPropertiesMatcher(configuration, mockServerLogger);
+        httpRequestsPropertiesMatcher.update(new Expectation(
+            new OpenAPIDefinition()
+                .withSpecUrlOrPayload("org/mockserver/openapi/openapi_petstore_example_with_operation_server.yaml")
+                .withOperationId("listPets")
+        ));
+        HttpRequest httpRequest = request()
+            .withMethod("GET")
+            .withPath("/v2/pets")
+            .withQueryStringParameter("limit", "10");
+        MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
+
+        // when
+        boolean matches = httpRequestsPropertiesMatcher.matches(context, httpRequest);
+
+        // then
+        thenMatchesEmptyFieldDifferences(context, matches, true);
+    }
+
+    @Test
+    public void shouldMatchSingleOperationInOpenAPIWithServerContainingVariablesYamlUrl() {
+        // given
+        HttpRequestsPropertiesMatcher httpRequestsPropertiesMatcher = new HttpRequestsPropertiesMatcher(configuration, mockServerLogger);
+        httpRequestsPropertiesMatcher.update(new Expectation(
+            new OpenAPIDefinition()
+                .withSpecUrlOrPayload("org/mockserver/openapi/openapi_petstore_example_with_server_url_variables.yaml")
+                .withOperationId("listPets")
+        ));
+        HttpRequest httpRequest = request()
+            .withMethod("GET")
+            .withPath("/v2/pets")
+            .withQueryStringParameter("limit", "10");
+        MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
+
+        // when
+        boolean matches = httpRequestsPropertiesMatcher.matches(context, httpRequest);
+
+        // then
+        thenMatchesEmptyFieldDifferences(context, matches, true);
+    }
+
+    @Test
+    public void shouldMatchSingleOperationInOpenAPIWithServerHavingNoPathPrefixYamlUrl() {
+        // given
+        HttpRequestsPropertiesMatcher httpRequestsPropertiesMatcher = new HttpRequestsPropertiesMatcher(configuration, mockServerLogger);
+        httpRequestsPropertiesMatcher.update(new Expectation(
+            new OpenAPIDefinition()
+                .withSpecUrlOrPayload("org/mockserver/openapi/openapi_petstore_example_with_no_path_prefix.yaml")
                 .withOperationId("listPets")
         ));
         HttpRequest httpRequest = request()
@@ -6184,7 +6250,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6206,7 +6272,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6228,7 +6294,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6241,12 +6307,12 @@ public class HttpRequestsPropertiesMatcherTest {
         assertThat(context.getDifferences(PATH), containsInAnyOrder(
             "  string or regex match failed expected:" + NEW_LINE +
                 NEW_LINE +
-                "    /pets/.*" + NEW_LINE +
+                "    /v1/pets/.*" + NEW_LINE +
                 NEW_LINE +
                 "   found:" + NEW_LINE +
                 NEW_LINE +
-                "    /pets" + NEW_LINE,
-            "  expected path /pets/{petId} has 2 parts but path /pets has 1 part "
+                "    /v1/pets" + NEW_LINE,
+            "  expected path /v1/pets/{petId} has 3 parts but path /v1/pets has 2 parts "
         ));
         assertThat(context.getDifferences(QUERY_PARAMETERS), nullValue());
         assertThat(context.getDifferences(COOKIES), nullValue());
@@ -6269,7 +6335,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6291,7 +6357,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("PUT")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6342,12 +6408,12 @@ public class HttpRequestsPropertiesMatcherTest {
         assertThat(context.getDifferences(PATH), containsInAnyOrder(
             "  string or regex match failed expected:" + NEW_LINE +
                 NEW_LINE +
-                "    /pets/.*" + NEW_LINE +
+                "    /v1/pets/.*" + NEW_LINE +
                 NEW_LINE +
                 "   found:" + NEW_LINE +
                 NEW_LINE +
                 "    /wrong" + NEW_LINE,
-            "  expected path /pets/{petId} has 2 parts but path /wrong has 1 part "
+            "  expected path /v1/pets/{petId} has 3 parts but path /wrong has 1 part "
         ));
         assertThat(context.getDifferences(QUERY_PARAMETERS), nullValue());
         assertThat(context.getDifferences(COOKIES), nullValue());
@@ -6370,7 +6436,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/some/path")
+            .withPath("/v1/some/path")
             .withQueryStringParameter("limit", "10");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6423,7 +6489,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/some/path")
+            .withPath("/v1/some/path")
             .withQueryStringParameter("limit", "not_a_number");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6475,7 +6541,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("GET")
-            .withPath("/some/path")
+            .withPath("/v1/some/path")
             .withQueryStringParameter("limit", "not_a_number");
         MatchDifference context = new MatchDifference(configuration.detailedMatchFailures(), httpRequest);
 
@@ -6486,18 +6552,18 @@ public class HttpRequestsPropertiesMatcherTest {
         assertThat(matches, is(false));
         assertThat(context.getDifferences(PATH), containsInAnyOrder("  string or regex match failed expected:" + NEW_LINE +
                 NEW_LINE +
-                "    /pets" + NEW_LINE +
+                "    /v1/pets" + NEW_LINE +
                 NEW_LINE +
                 "   found:" + NEW_LINE +
                 NEW_LINE +
-                "    /some/path" + NEW_LINE,
+                "    /v1/some/path" + NEW_LINE,
             "  string or regex match failed expected:" + NEW_LINE +
                 NEW_LINE +
-                "    /pets/.*" + NEW_LINE +
+                "    /v1/pets/.*" + NEW_LINE +
                 NEW_LINE +
                 "   found:" + NEW_LINE +
                 NEW_LINE +
-                "    /some/path" + NEW_LINE));
+                "    /v1/some/path" + NEW_LINE));
         assertThat(context.getDifferences(METHOD), containsInAnyOrder("  string or regex match failed expected:" + NEW_LINE +
                 NEW_LINE +
                 "    POST" + NEW_LINE +
@@ -6554,7 +6620,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("POST")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withHeader("content-type", "application/json")
             .withBody(json("{" + NEW_LINE +
                 "    \"id\": \"invalid_id_format\", " + NEW_LINE +
@@ -6622,7 +6688,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("POST")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withHeader("content-type", "application/json")
             .withBody(json("{" + NEW_LINE +
                 "    \"id\": \"invalid_id_format\", " + NEW_LINE +
@@ -6698,7 +6764,7 @@ public class HttpRequestsPropertiesMatcherTest {
         ));
         HttpRequest httpRequest = request()
             .withMethod("POST")
-            .withPath("/pets")
+            .withPath("/v1/pets")
             .withBody(json("{" + NEW_LINE +
                 "    \"id\": \"invalid_id_format\", " + NEW_LINE +
                 "    \"name\": \"scruffles\", " + NEW_LINE +

--- a/mockserver-core/src/test/java/org/mockserver/mock/MockServerMatcherClearAndResetTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mock/MockServerMatcherClearAndResetTest.java
@@ -132,7 +132,7 @@ public class MockServerMatcherClearAndResetTest {
             new Expectation(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10")
             ),
             new Expectation(request().withPath("def")).thenRespond(response().withBody("somebody"))
@@ -161,7 +161,7 @@ public class MockServerMatcherClearAndResetTest {
             new Expectation(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10")
             ),
             new Expectation(request().withPath("def")).thenRespond(response().withBody("somebody"))
@@ -187,7 +187,7 @@ public class MockServerMatcherClearAndResetTest {
             new Expectation(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10")
             ),
             new Expectation(request().withPath("def")).thenRespond(response().withBody("somebody"))
@@ -216,7 +216,7 @@ public class MockServerMatcherClearAndResetTest {
             new Expectation(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10")
             ),
             new Expectation(request().withPath("def")).thenRespond(response().withBody("somebody"))

--- a/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_no_path_prefix.yaml
+++ b/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_no_path_prefix.yaml
@@ -1,0 +1,191 @@
+---
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pets"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        description: a pet
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          "*/*":
+            schema:
+              "$ref": "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Null response
+        '400':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/some/path":
+    get:
+      summary: Additional request with extra matchers
+      operationId: somePath
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_operation_server.yaml
+++ b/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_operation_server.yaml
@@ -1,0 +1,193 @@
+---
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  "/pets":
+    servers:
+      - url: http://petstore.swagger.io/v2
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pets"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        description: a pet
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          "*/*":
+            schema:
+              "$ref": "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Null response
+        '400':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/some/path":
+    get:
+      summary: Additional request with extra matchers
+      operationId: somePath
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_operation_server.yaml
+++ b/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_operation_server.yaml
@@ -16,6 +16,11 @@ paths:
       operationId: listPets
       tags:
         - pets
+      servers:
+        - url: http://petstore.swagger.io/{version}
+          variables:
+            version:
+              default: v3
       parameters:
         - name: limit
           in: query

--- a/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_server_url_variables.yaml
+++ b/mockserver-core/src/test/resources/org/mockserver/openapi/openapi_petstore_example_with_server_url_variables.yaml
@@ -1,0 +1,200 @@
+---
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io:{port}/{basePath}
+    variables:
+      port:
+        enum:
+          - '8443'
+          - '443'
+        default: '8443'
+      basePath:
+        default: v2
+  - url: http://petstore.swagger.io/v1
+paths:
+  "/pets":
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pets"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        description: a pet
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          "*/*":
+            schema:
+              "$ref": "#/components/schemas/Pet"
+      responses:
+        '201':
+          description: Null response
+        '400':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/pets/{petId}":
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '500':
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/some/path":
+    get:
+      summary: Additional request with extra matchers
+      operationId: somePath
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            format: int32
+        - in: header
+          name: X-Request-ID
+          schema:
+            type: string
+            format: uuid
+          required: true
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      items:
+        "$ref": "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/mockserver-integration-testing/src/main/java/org/mockserver/testing/integration/mock/AbstractBasicMockingIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/testing/integration/mock/AbstractBasicMockingIntegrationTest.java
@@ -585,7 +585,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -622,7 +622,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -638,7 +638,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withBody(json("{" + NEW_LINE +
                         "  \"id\" : 0," + NEW_LINE +
                         "  \"name\" : \"some_string_value\"," + NEW_LINE +
@@ -659,7 +659,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets/12345")
+                    .withPath("/v1/pets/12345")
                     .withHeader("x-request-id", UUIDService.getUUID()),
                 HEADERS_TO_IGNORE)
         );
@@ -949,7 +949,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("PUT")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -1281,7 +1281,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -1291,7 +1291,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -1493,7 +1493,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -1503,7 +1503,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -1726,7 +1726,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -1743,7 +1743,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -1762,11 +1762,11 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             mockServerClient.retrieveRecordedRequests(openAPI().withSpecUrlOrPayload(FileReader.readFileFromClassPathOrPath("org/mockserver/openapi/openapi_petstore_example.json"))),
             request()
                 .withMethod("GET")
-                .withPath("/pets")
+                .withPath("/v1/pets")
                 .withQueryStringParameter("limit", "10"),
             request()
                 .withMethod("POST")
-                .withPath("/pets")
+                .withPath("/v1/pets")
                 .withHeader("content-type", "application/json")
                 .withBody(json("" +
                     "{" + NEW_LINE +
@@ -2259,7 +2259,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -2276,7 +2276,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -2320,7 +2320,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )

--- a/mockserver-integration-testing/src/main/java/org/mockserver/testing/integration/mock/AbstractBasicMockingSameJVMIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/testing/integration/mock/AbstractBasicMockingSameJVMIntegrationTest.java
@@ -467,7 +467,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -478,7 +478,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withBody(json("{" + NEW_LINE +
                         "  \"id\" : 0," + NEW_LINE +
                         "  \"name\" : \"some_string_value\"," + NEW_LINE +
@@ -499,7 +499,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets/12345")
+                    .withPath("/v1/pets/12345")
                     .withHeader("x-request-id", UUIDService.getUUID()),
                 HEADERS_TO_IGNORE)
         );
@@ -574,7 +574,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -601,7 +601,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -628,7 +628,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("PUT")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE)
         );
@@ -652,7 +652,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -662,7 +662,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -698,7 +698,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -708,7 +708,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -766,7 +766,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -783,7 +783,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -802,11 +802,11 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             mockServerClient.retrieveRecordedRequests(openAPI().withSpecUrlOrPayload("org/mockserver/openapi/openapi_petstore_example.json")),
             request()
                 .withMethod("GET")
-                .withPath("/pets")
+                .withPath("/v1/pets")
                 .withQueryStringParameter("limit", "10"),
             request()
                 .withMethod("POST")
-                .withPath("/pets")
+                .withPath("/v1/pets")
                 .withHeader("content-type", "application/json")
                 .withBody(json("" +
                     "{" + NEW_LINE +
@@ -840,7 +840,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )
@@ -857,7 +857,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -901,7 +901,7 @@ public abstract class AbstractBasicMockingSameJVMIntegrationTest extends Abstrac
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 HEADERS_TO_IGNORE
             )

--- a/mockserver-junit-jupiter/src/test/java/org/mockserver/junit/jupiter/integration/AbstractBasicMockingIntegrationTest.java
+++ b/mockserver-junit-jupiter/src/test/java/org/mockserver/junit/jupiter/integration/AbstractBasicMockingIntegrationTest.java
@@ -426,7 +426,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore)
         );
@@ -456,7 +456,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore)
         );
@@ -483,7 +483,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore)
         );
@@ -517,7 +517,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore)
         );
@@ -528,7 +528,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withBody(json("{" + NEW_LINE +
                         "  \"id\" : 0," + NEW_LINE +
                         "  \"name\" : \"some_string_value\"," + NEW_LINE +
@@ -549,7 +549,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets/12345")
+                    .withPath("/v1/pets/12345")
                     .withHeader("x-request-id", UUIDService.getUUID()),
                 headersToIgnore)
         );
@@ -631,7 +631,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore)
         );
@@ -647,7 +647,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withBody(json("{" + NEW_LINE +
                         "  \"id\" : 0," + NEW_LINE +
                         "  \"name\" : \"some_string_value\"," + NEW_LINE +
@@ -668,7 +668,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath("/pets/12345")
+                    .withPath("/v1/pets/12345")
                     .withHeader("x-request-id", UUIDService.getUUID()),
                 headersToIgnore)
         );
@@ -920,7 +920,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("PUT")
-                    .withPath("/pets")
+                    .withPath("/v1/pets")
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore)
         );
@@ -1161,7 +1161,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("GET")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withQueryStringParameter("limit", "10"),
                 headersToIgnore
             )
@@ -1178,7 +1178,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             makeRequest(
                 request()
                     .withMethod("POST")
-                    .withPath(calculatePath("/pets"))
+                    .withPath(calculatePath("/v1/pets"))
                     .withHeader("content-type", "application/json")
                     .withBody(json("" +
                         "{" + NEW_LINE +
@@ -1197,11 +1197,11 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
             mockServerClient.retrieveRecordedRequests(openAPI().withSpecUrlOrPayload("org/mockserver/openapi/openapi_petstore_example.json")),
             request()
                 .withMethod("GET")
-                .withPath("/pets")
+                .withPath("/v1/pets")
                 .withQueryStringParameter("limit", "10"),
             request()
                 .withMethod("POST")
-                .withPath("/pets")
+                .withPath("/v1/pets")
                 .withHeader("content-type", "application/json")
                 .withBody(json("" +
                     "{" + NEW_LINE +

--- a/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/ExpectationInitializerIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/ExpectationInitializerIntegrationTest.java
@@ -142,7 +142,7 @@ public class ExpectationInitializerIntegrationTest {
                     request()
                         .withMethod("GET")
                         .withHeader(HOST.toString(), "localhost:" + mockServer.getLocalPort())
-                        .withPath("/pets")
+                        .withPath("/v1/pets")
                 ).get(10, TimeUnit.SECONDS).getBodyAsString(),
                 is("{" + NEW_LINE +
                     "  \"code\" : 0," + NEW_LINE +

--- a/scripts/buildkite_quick_build.sh
+++ b/scripts/buildkite_quick_build.sh
@@ -19,4 +19,4 @@ fi
 echo "whoami: "
 whoami
 
-./mvnw clean install $1 -DskipAssembly=true
+./mvnw clean install $1


### PR DESCRIPTION
fixes #1281 support for server urls in OpenAPI specification, by adding server url path as path prefix to operations