### PR TITLE
SSL-Context is now configureable independently for server and client

### DIFF
--- a/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
+++ b/mockserver-client-java/src/main/java/org/mockserver/client/MockServerClient.java
@@ -339,7 +339,7 @@ public class MockServerClient implements Stoppable {
 
     private NettyHttpClient getNettyHttpClient() {
         if (nettyHttpClient == null) {
-            NettySslContextFactory nettySslContextFactory = new NettySslContextFactory(configuration.toServerConfiguration(), MOCK_SERVER_LOGGER);
+            NettySslContextFactory nettySslContextFactory = new NettySslContextFactory(configuration.toServerConfiguration(), MOCK_SERVER_LOGGER, false);
             Function<SslContextBuilder, SslContext> clientSslContextBuilderFunction = NettySslContextFactory.clientSslContextBuilderFunction;
             if (configuration.controlPlaneTLSMutualAuthenticationRequired()) {
                 if (isBlank(configuration.controlPlanePrivateKeyPath()) || isBlank(configuration.controlPlaneX509CertificatePath()) || isBlank(configuration.controlPlaneTLSMutualAuthenticationCAChain())) {

--- a/mockserver-core/src/main/java/org/mockserver/echo/http/EchoServerInitializer.java
+++ b/mockserver-core/src/main/java/org/mockserver/echo/http/EchoServerInitializer.java
@@ -59,7 +59,7 @@ public class EchoServerInitializer extends ChannelInitializer<SocketChannel> {
         }
 
         if (secure) {
-            pipeline.addLast((sslContext != null ? sslContext : new NettySslContextFactory(configuration, mockServerLogger).createServerSslContext()).newHandler(channel.alloc()));
+            pipeline.addLast((sslContext != null ? sslContext : new NettySslContextFactory(configuration, mockServerLogger, true).createServerSslContext()).newHandler(channel.alloc()));
         }
 
         if (MockServerLogger.isEnabled(TRACE)) {

--- a/mockserver-core/src/main/java/org/mockserver/httpclient/NettyHttpClient.java
+++ b/mockserver-core/src/main/java/org/mockserver/httpclient/NettyHttpClient.java
@@ -52,7 +52,7 @@ public class NettyHttpClient {
     private final NettySslContextFactory nettySslContextFactory;
 
     public NettyHttpClient(Configuration configuration, MockServerLogger mockServerLogger, EventLoopGroup eventLoopGroup, List<ProxyConfiguration> proxyConfigurations, boolean forwardProxyClient) {
-        this(configuration, mockServerLogger, eventLoopGroup, proxyConfigurations, forwardProxyClient, new NettySslContextFactory(configuration, mockServerLogger));
+        this(configuration, mockServerLogger, eventLoopGroup, proxyConfigurations, forwardProxyClient, new NettySslContextFactory(configuration, mockServerLogger, false));
     }
 
     public NettyHttpClient(Configuration configuration, MockServerLogger mockServerLogger, EventLoopGroup eventLoopGroup, List<ProxyConfiguration> proxyConfigurations, boolean forwardProxyClient, NettySslContextFactory nettySslContextFactory) {

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/KeyAndCertificateFactoryFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/KeyAndCertificateFactoryFactory.java
@@ -5,6 +5,7 @@ import org.mockserver.logging.MockServerLogger;
 import org.mockserver.socket.tls.bouncycastle.BCKeyAndCertificateFactory;
 
 import java.lang.reflect.Constructor;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -12,13 +13,17 @@ import java.util.function.Function;
  */
 public class KeyAndCertificateFactoryFactory {
 
-    private static Function<MockServerLogger, KeyAndCertificateFactory> customKeyAndCertificateFactorySupplier = null;
+    private static BiFunction<MockServerLogger, Boolean, KeyAndCertificateFactory> customKeyAndCertificateFactorySupplier = null;
 
     private static final ClassLoader CLASS_LOADER = KeyAndCertificateFactoryFactory.class.getClassLoader();
 
     public static KeyAndCertificateFactory createKeyAndCertificateFactory(Configuration configuration, MockServerLogger mockServerLogger) {
+        return createKeyAndCertificateFactory(configuration, mockServerLogger, true);
+    }
+
+    public static KeyAndCertificateFactory createKeyAndCertificateFactory(Configuration configuration, MockServerLogger mockServerLogger, boolean isServerInstance) {
         if (customKeyAndCertificateFactorySupplier != null) {
-            return customKeyAndCertificateFactorySupplier.apply(mockServerLogger);
+            return customKeyAndCertificateFactorySupplier.apply(mockServerLogger, isServerInstance);
         } else {
             return new BCKeyAndCertificateFactory(configuration, mockServerLogger);
         }
@@ -53,11 +58,12 @@ public class KeyAndCertificateFactoryFactory {
         return bouncyCastleProvider == null || bouncyCastleX509Holder == null;
     }
 
-    public static Function<MockServerLogger, KeyAndCertificateFactory> getCustomKeyAndCertificateFactorySupplier() {
+    public static BiFunction<MockServerLogger, Boolean, KeyAndCertificateFactory> getCustomKeyAndCertificateFactorySupplier() {
         return customKeyAndCertificateFactorySupplier;
     }
 
-    public static void setCustomKeyAndCertificateFactorySupplier(Function<MockServerLogger, KeyAndCertificateFactory> customKeyAndCertificateFactorySupplier) {
+    public static void setCustomKeyAndCertificateFactorySupplier(
+        BiFunction<MockServerLogger, Boolean, KeyAndCertificateFactory> customKeyAndCertificateFactorySupplier) {
         KeyAndCertificateFactoryFactory.customKeyAndCertificateFactorySupplier = customKeyAndCertificateFactorySupplier;
     }
 }

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.mockserver.configuration.Configuration.configuration;
@@ -44,6 +46,8 @@ public class NettySslContextFactory {
                 throw new RuntimeException(e);
             }
         };
+    public static Consumer<NettySslContextFactory> nettySslContextFactoryCustomizer = factory -> {
+    };
 
     private final Configuration configuration;
     private final MockServerLogger mockServerLogger;
@@ -51,6 +55,7 @@ public class NettySslContextFactory {
     private SslContext clientSslContext = null;
     private SslContext serverSslContext = null;
     private Function<SslContextBuilder, SslContext> instanceClientSslContextBuilderFunction = clientSslContextBuilderFunction;
+    private final boolean isServerInstance;
 
     /**
      * @deprecated use constructor that specifies configuration explicitly
@@ -59,6 +64,7 @@ public class NettySslContextFactory {
     public NettySslContextFactory(MockServerLogger mockServerLogger) {
         this.configuration = configuration();
         this.mockServerLogger = mockServerLogger;
+        this.isServerInstance = true;
         keyAndCertificateFactory = createKeyAndCertificateFactory(configuration, mockServerLogger);
         System.setProperty("https.protocols", Joiner.on(",").join(TLS_PROTOCOLS));
         if (configuration.proactivelyInitialiseTLS()) {
@@ -66,9 +72,10 @@ public class NettySslContextFactory {
         }
     }
 
-    public NettySslContextFactory(Configuration configuration, MockServerLogger mockServerLogger) {
+    public NettySslContextFactory(Configuration configuration, MockServerLogger mockServerLogger, boolean isServerInstance) {
         this.configuration = configuration;
         this.mockServerLogger = mockServerLogger;
+        this.isServerInstance = isServerInstance;
         keyAndCertificateFactory = createKeyAndCertificateFactory(configuration, mockServerLogger);
         System.setProperty("https.protocols", Joiner.on(",").join(TLS_PROTOCOLS));
         if (configuration.proactivelyInitialiseTLS()) {
@@ -234,4 +241,7 @@ public class NettySslContextFactory {
         }
     }
 
+    public boolean isServerInstance() {
+        return isServerInstance;
+    }
 }

--- a/mockserver-core/src/test/java/org/mockserver/socket/tls/CustomKeyAndCertificateFactorySupplierTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/socket/tls/CustomKeyAndCertificateFactorySupplierTest.java
@@ -1,13 +1,12 @@
 package org.mockserver.socket.tls;
 
+import java.util.function.BiFunction;
 import org.junit.Test;
 import org.mockserver.configuration.Configuration;
 import org.mockserver.logging.MockServerLogger;
-import org.mockserver.socket.tls.bouncycastle.BCKeyAndCertificateFactory;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,7 +16,7 @@ public class CustomKeyAndCertificateFactorySupplierTest {
 
     @Test
     public void shouldReturnCustomFactory() {
-        Function<MockServerLogger, KeyAndCertificateFactory> originalCustomKeyAndCertificateFactorySupplier = KeyAndCertificateFactoryFactory.getCustomKeyAndCertificateFactorySupplier();
+        BiFunction<MockServerLogger, Boolean, KeyAndCertificateFactory> originalCustomKeyAndCertificateFactorySupplier = KeyAndCertificateFactoryFactory.getCustomKeyAndCertificateFactorySupplier();
 
         // given
         Configuration configuration = configuration();
@@ -54,7 +53,7 @@ public class CustomKeyAndCertificateFactorySupplierTest {
 
         try {
             // when
-            KeyAndCertificateFactoryFactory.setCustomKeyAndCertificateFactorySupplier(logger -> factoryInstance);
+            KeyAndCertificateFactoryFactory.setCustomKeyAndCertificateFactorySupplier((logger, isServer) -> factoryInstance);
 
             // then
             assertThat(KeyAndCertificateFactoryFactory.createKeyAndCertificateFactory(configuration, mockServerLogger), equalTo(factoryInstance));

--- a/mockserver-netty/src/test/java/org/mockserver/netty/integration/authenticatedcontrolplane/AuthenticatedControlPlaneUsingMTLSClientNotAuthenticatedIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/netty/integration/authenticatedcontrolplane/AuthenticatedControlPlaneUsingMTLSClientNotAuthenticatedIntegrationTest.java
@@ -84,7 +84,7 @@ public class AuthenticatedControlPlaneUsingMTLSClientNotAuthenticatedIntegration
 
         mockServerClient = new MockServerClient("localhost", mockServerClient.getPort()).withSecure(true);
         MockServerLogger mockServerLogger = new MockServerLogger();
-        NettySslContextFactory nettySslContextFactory = new NettySslContextFactory(configuration(), MOCK_SERVER_LOGGER);
+        NettySslContextFactory nettySslContextFactory = new NettySslContextFactory(configuration(), MOCK_SERVER_LOGGER, false);
         nettySslContextFactory.withClientSslContextBuilderFunction(
             sslContextBuilder -> {
                 try {

--- a/mockserver-netty/src/test/java/org/mockserver/netty/integration/tls/inbound/ClientAuthenticationAdditionalCertificateChainMockingIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/netty/integration/tls/inbound/ClientAuthenticationAdditionalCertificateChainMockingIntegrationTest.java
@@ -135,7 +135,8 @@ public class ClientAuthenticationAdditionalCertificateChainMockingIntegrationTes
     }
 
     private SSLContext getSslContext() {
-        KeyAndCertificateFactory keyAndCertificateFactory = KeyAndCertificateFactoryFactory.createKeyAndCertificateFactory(configuration(), new MockServerLogger());
+        KeyAndCertificateFactory keyAndCertificateFactory
+            = KeyAndCertificateFactoryFactory.createKeyAndCertificateFactory(configuration(), new MockServerLogger());
         assertThat(keyAndCertificateFactory, notNullValue());
         keyAndCertificateFactory.buildAndSavePrivateKeyAndX509Certificate();
         return new KeyStoreFactory(configuration(), new MockServerLogger())

--- a/mockserver-proxy-war/src/main/java/org/mockserver/proxyservlet/ProxyServlet.java
+++ b/mockserver-proxy-war/src/main/java/org/mockserver/proxyservlet/ProxyServlet.java
@@ -66,7 +66,7 @@ public class ProxyServlet extends HttpServlet implements ServletContextListener 
         this.mockServerLogger = httpStateHandler.getMockServerLogger();
         this.portBindingSerializer = new PortBindingSerializer(mockServerLogger);
         this.workerGroup = new NioEventLoopGroup(configuration.nioEventLoopThreadCount(), new Scheduler.SchedulerThreadFactory(this.getClass().getSimpleName() + "-eventLoop"));
-        this.actionHandler = new HttpActionHandler(configuration(), workerGroup, httpStateHandler, null, new NettySslContextFactory(this.configuration, this.mockServerLogger));
+        this.actionHandler = new HttpActionHandler(configuration(), workerGroup, httpStateHandler, null, new NettySslContextFactory(this.configuration, this.mockServerLogger, true));
     }
 
     @Override

--- a/mockserver-war/src/main/java/org/mockserver/mockservlet/MockServerServlet.java
+++ b/mockserver-war/src/main/java/org/mockserver/mockservlet/MockServerServlet.java
@@ -66,7 +66,7 @@ public class MockServerServlet extends HttpServlet implements ServletContextList
         this.mockServerLogger = httpStateHandler.getMockServerLogger();
         this.portBindingSerializer = new PortBindingSerializer(mockServerLogger);
         this.workerGroup = new NioEventLoopGroup(configuration.nioEventLoopThreadCount(), new Scheduler.SchedulerThreadFactory(this.getClass().getSimpleName() + "-eventLoop"));
-        this.actionHandler = new HttpActionHandler(configuration(), workerGroup, httpStateHandler, null, new NettySslContextFactory(this.configuration, this.mockServerLogger));
+        this.actionHandler = new HttpActionHandler(configuration(), workerGroup, httpStateHandler, null, new NettySslContextFactory(this.configuration, this.mockServerLogger, true));
     }
 
     @Override


### PR DESCRIPTION
To further enable customization of SSL-Contexts the factory now can distinguish if it is being asked to supply a context for a server or a client. This enables MockServer to present completely different Contexts for the server- and client-side. This is in addition to the customization in the configuration as it supplies more information to runtime customization (namely in the `KeyAndCertificateFactoryFactory.customKeyAndCertificateFactorySupplier`)