### PR TITLE
Enable full SSL chain customization

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/KeyAndCertificateFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/KeyAndCertificateFactory.java
@@ -5,6 +5,7 @@ import org.mockserver.keys.AsymmetricKeyPairAlgorithm;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.List;
 
 /**
  * @author jamesdbloom
@@ -64,5 +65,7 @@ public interface KeyAndCertificateFactory {
     X509Certificate x509Certificate();
 
     X509Certificate certificateAuthorityX509Certificate();
+
+    List<X509Certificate> certificateChain();
 
 }

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
@@ -193,8 +193,7 @@ public class NettySslContextFactory {
                 SslContextBuilder sslContextBuilder = SslContextBuilder
                     .forServer(
                         keyAndCertificateFactory.privateKey(),
-                        keyAndCertificateFactory.x509Certificate(),
-                        keyAndCertificateFactory.certificateAuthorityX509Certificate()
+                        keyAndCertificateFactory.certificateChain()
                     )
                     .protocols(TLS_PROTOCOLS)
 //                    .sslProvider(SslProvider.JDK)

--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/bouncycastle/BCKeyAndCertificateFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/bouncycastle/BCKeyAndCertificateFactory.java
@@ -15,6 +15,7 @@ import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.IPAddress;
 import org.mockserver.configuration.Configuration;
+import org.mockserver.configuration.ConfigurationProperties;
 import org.mockserver.file.FileCreator;
 import org.mockserver.file.FilePath;
 import org.mockserver.file.FileReader;
@@ -376,4 +377,11 @@ public class BCKeyAndCertificateFactory implements KeyAndCertificateFactory {
         }
     }
 
+    @Override
+    public List<X509Certificate> certificateChain() {
+        final List<X509Certificate> result = new ArrayList<>();
+        result.add(x509Certificate());
+        result.add(certificateAuthorityX509Certificate());
+        return result;
+    }
 }

--- a/mockserver-core/src/test/java/org/mockserver/socket/tls/CustomKeyAndCertificateFactorySupplierTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/socket/tls/CustomKeyAndCertificateFactorySupplierTest.java
@@ -1,5 +1,6 @@
 package org.mockserver.socket.tls;
 
+import java.util.List;
 import org.junit.Test;
 import org.mockserver.configuration.Configuration;
 import org.mockserver.logging.MockServerLogger;
@@ -48,6 +49,11 @@ public class CustomKeyAndCertificateFactorySupplierTest {
 
             @Override
             public X509Certificate certificateAuthorityX509Certificate() {
+                return null;
+            }
+
+            @Override
+            public List<X509Certificate> certificateChain() {
                 return null;
             }
         };


### PR DESCRIPTION
Added a callback enabling the cutomization of not just the EE-certificate of an SSL-Context but the complete chain as well. Functionally equivalent.