### PR TITLE
Configureable SSL Customizers

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
+++ b/mockserver-core/src/main/java/org/mockserver/socket/tls/NettySslContextFactory.java
@@ -133,7 +133,8 @@ public class NettySslContextFactory {
                     }
                     sslContextBuilder.trustManager(jvmCAX509TrustCertificates(mockServerX509Certificates));
                 }
-                clientSslContext = instanceClientSslContextBuilderFunction.apply(sslContextBuilder);
+                clientSslContext = instanceClientSslContextBuilderFunction.apply(
+                    sslClientContextBuilderCustomizer.apply(sslContextBuilder));
                 configuration.rebuildTLSContext(false);
             } catch (Throwable throwable) {
                 throw new RuntimeException("Exception creating SSL context for client", throwable);

--- a/mockserver-core/src/test/java/org/mockserver/socket/tls/CustomKeyAndCertificateFactorySupplierTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/socket/tls/CustomKeyAndCertificateFactorySupplierTest.java
@@ -1,6 +1,9 @@
 package org.mockserver.socket.tls;
 
 import org.junit.Test;
+import org.junit.AfterClass;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.mockserver.configuration.Configuration;
 import org.mockserver.logging.MockServerLogger;
 import org.mockserver.socket.tls.bouncycastle.BCKeyAndCertificateFactory;
@@ -9,6 +12,8 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.function.Function;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockserver.configuration.Configuration.configuration;
@@ -63,4 +68,36 @@ public class CustomKeyAndCertificateFactorySupplierTest {
         }
     }
 
+    @Test
+    public void setServerModifier_shouldBeCalled() {
+        final AtomicBoolean customizerCallFlag = new AtomicBoolean(false);
+        NettySslContextFactory.sslServerContextBuilderCustomizer = builder -> {
+            customizerCallFlag.set(true);
+            return builder;
+        };
+
+        new NettySslContextFactory(new Configuration(), mock(MockServerLogger.class), true)
+            .createServerSslContext();
+
+        assertTrue(customizerCallFlag.get());
+    }
+
+    @Test
+    public void setClientModifier_shouldBeCalled() {
+        final AtomicBoolean customizerCallFlag = new AtomicBoolean(false);
+        NettySslContextFactory.sslClientContextBuilderCustomizer = builder -> {
+            customizerCallFlag.set(true);
+            return builder;
+        };
+
+        new NettySslContextFactory(new Configuration(), mock(MockServerLogger.class), false)
+            .createClientSslContext(false);
+
+        assertTrue(customizerCallFlag.get());
+    }
+
+    @AfterClass
+    public static void resetSupplier() {
+        KeyAndCertificateFactoryFactory.setCustomKeyAndCertificateFactorySupplier(null);
+    }
 }


### PR DESCRIPTION
This allows the full customization of both the client and the server SSL context. This is necessary for example to allow for SSL-Suites modification.

This PR is merged off from https://github.com/mock-server/mockserver/pull/1329, so it should be merged after that (and will work without conflicts)