### PR TITLE
fix: Kubernetes ingress for newer k8s versions (>= 1.19-0)

### DIFF
--- a/helm/mockserver/templates/ingress.yaml
+++ b/helm/mockserver/templates/ingress.yaml
@@ -36,11 +36,16 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
-            pathType: {{ $ingressPathType }}
             backend:
+  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $servicePort }}
+            pathType: {{ $ingressPathType }}
+  {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $serviceport }}
+  {{- end }}
   {{- end }}
   {{- end }}

--- a/helm/mockserver/templates/ingress.yaml
+++ b/helm/mockserver/templates/ingress.yaml
@@ -36,7 +36,9 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: serviceport
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $servicePort }}
   {{- end }}
   {{- end }}

--- a/helm/mockserver/templates/ingress.yaml
+++ b/helm/mockserver/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-  {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.22-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/helm/mockserver/templates/ingress.yaml
+++ b/helm/mockserver/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
             pathType: {{ $ingressPathType }}
   {{- else }}
               serviceName: {{ $fullName }}
-              servicePort: {{ $serviceport }}
+              servicePort: {{ $servicePort }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/helm/mockserver/templates/ingress.yaml
+++ b/helm/mockserver/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-  {{- if semverCompare ">=1.22-0" $.Capabilities.KubeVersion.GitVersion }}
+  {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:

--- a/helm/mockserver/templates/ingress.yaml
+++ b/helm/mockserver/templates/ingress.yaml
@@ -2,6 +2,7 @@
 {{- $fullName := include "chart.fullname" . -}}
 {{- $servicePort := .Values.service.port -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressPathType := .Values.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -35,6 +36,7 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: {{ $ingressPathType }}
             backend:
               service:
                 name: {{ $fullName }}

--- a/helm/mockserver/values.yaml
+++ b/helm/mockserver/values.yaml
@@ -37,6 +37,7 @@ ingress:
   path: /
   hosts:
     - mockserver.local
+  tls: []
 
 podAnnotations: {}
 

--- a/helm/mockserver/values.yaml
+++ b/helm/mockserver/values.yaml
@@ -35,6 +35,7 @@ ingress:
   enabled: false
   annotations: {}
   path: /
+  pathType: Prefix
   hosts:
     - mockserver.local
   tls: []


### PR DESCRIPTION
To be able to deploy this helm chart in Kubernetes clusters with Kubernetes Cluster version >= 1.19, the changes in this PR should be made (different svc spec, pathType; see: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122). Furthermore I've included a standard value in the `ingress.tls` field, for good measure.

I don't know if this is worth mentioning in the `changelog.md` as its basically just an addition to https://github.com/mock-server/mockserver/commit/6f48421994b36eac6475f2a482842c179b0f8f2c