### PR TITLE
Add CI pipeline for building and pushing multi-arch Docker image

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,31 @@
+name: Build and push Docker image to Docker Hub
+on:
+  push:
+    tags:
+      - mockserver-*
+
+jobs:
+  build-and-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Get tag name
+        id: get_tag_version
+        run: echo "::set-output name=version::${GITHUB_REF/refs\/tags\//}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: mockserver/mockserver:${{ steps.get_tag_version.outputs.version }}


### PR DESCRIPTION
This PR adds a CI pipeline for automatically building and pushing a Docker image to Docker Hub on every GitHub tag that is created.

See it in action here: https://github.com/dennisameling/mockserver/runs/7864265832?check_suite_focus=true (published to https://hub.docker.com/r/dennisameling/mockserver/tags)

Closes #1428 and https://trello.com/c/fUHwzasD/153-add-arm64-docker-image-for-hosting-on-raspberrypi-devices