### PR TITLE
Resolve OpenAPI Specification Components NullPointerException

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/openapi/OpenAPIConverter.java
+++ b/mockserver-core/src/main/java/org/mockserver/openapi/OpenAPIConverter.java
@@ -82,7 +82,7 @@ public class OpenAPIConverter {
                             if (example != null) {
                                 response.withHeader(entry.getKey(), String.valueOf(example.getValue()));
                             } else if (value.getSchema() != null) {
-                                org.mockserver.openapi.examples.models.Example generatedExample = ExampleBuilder.fromSchema(value.getSchema(), openAPI.getComponents().getSchemas());
+                                org.mockserver.openapi.examples.models.Example generatedExample = ExampleBuilder.fromSchema(value.getSchema(), openAPI.getComponents() != null ? openAPI.getComponents().getSchemas() : null);
                                 if (generatedExample instanceof StringExample) {
                                     response.withHeader(entry.getKey(), ((StringExample) generatedExample).getValue());
                                 } else {
@@ -125,7 +125,7 @@ public class OpenAPIConverter {
                                             response.withBody(((StringExample) generatedExample).getValue());
                                         }
                                     } else {
-                                        org.mockserver.openapi.examples.models.Example exampleFromSchema = ExampleBuilder.fromSchema(mediaType.getSchema(), openAPI.getComponents().getSchemas());
+                                        org.mockserver.openapi.examples.models.Example exampleFromSchema = ExampleBuilder.fromSchema(mediaType.getSchema(), openAPI.getComponents() != null ? openAPI.getComponents().getSchemas() : null);
                                         if (exampleFromSchema != null) {
                                             String serialise = serialise(exampleFromSchema);
                                             if (isJsonContentType(contentType.getKey())) {


### PR DESCRIPTION
Adding a null conditional check before accessing Schemas from OAS Components. If Components is not set, we default to null for retrieving Example from Schema.

This is in response to Issue #1446.