### PR TITLE
Amend typo in configuring_sut.html

### DIFF
--- a/jekyll-www.mock-server.com/proxy/configuring_sut.html
+++ b/jekyll-www.mock-server.com/proxy/configuring_sut.html
@@ -50,7 +50,7 @@ sitemap:
 
 <p>Although the port forwarding proxy is the simplest proxy is can only proxy a single remote port and host. To forward multiple ports, multiple port forwarding proxies, should be run as separate processes.</p>
 
-<p>There are two many approaches for routing requests via the port forwarding proxy.</p>
+<p>There are two main approaches for routing requests via the port forwarding proxy.</p>
 
 <ol>
 	<li>Update the remote service host and port used by the client, typically this is either hard coded or in a configuration file. Change the remote service host and port to the host and port where the proxy is running.</li>


### PR DESCRIPTION
"There are two many" reads better as "There are two main"