### PR TITLE
Changed remoteAddress formatting

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/mappers/FullHttpRequestToMockServerHttpRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/FullHttpRequestToMockServerHttpRequest.java
@@ -90,7 +90,7 @@ public class FullHttpRequestToMockServerHttpRequest {
     private void setSocketAddress(HttpRequest httpRequest, FullHttpRequest fullHttpRequest, boolean isSecure, Integer port, SocketAddress localAddress, SocketAddress remoteAddress) {
         httpRequest.withSocketAddress(isSecure, fullHttpRequest.headers().get("host"), port);
         if (remoteAddress instanceof InetSocketAddress) {
-            httpRequest.withRemoteAddress(((InetSocketAddress) remoteAddress).getHostString());
+            httpRequest.withRemoteAddress(StringUtils.removeStart(remoteAddress.toString(), "/"));
         }
         if (localAddress instanceof InetSocketAddress) {
             httpRequest.withLocalAddress(StringUtils.removeStart(localAddress.toString(), "/"));

--- a/mockserver-core/src/main/java/org/mockserver/mappers/HttpServletRequestToMockServerHttpRequestDecoder.java
+++ b/mockserver-core/src/main/java/org/mockserver/mappers/HttpServletRequestToMockServerHttpRequestDecoder.java
@@ -46,7 +46,7 @@ public class HttpServletRequestToMockServerHttpRequestDecoder {
         request.withKeepAlive(isKeepAlive(httpServletRequest));
         request.withSecure(httpServletRequest.isSecure());
         request.withLocalAddress(httpServletRequest.getLocalAddr() + ":" + httpServletRequest.getLocalPort());
-        request.withRemoteAddress(httpServletRequest.getRemoteHost());
+        request.withRemoteAddress(httpServletRequest.getRemoteHost() + ":" + httpServletRequest.getRemotePort());
         return request;
     }
 

--- a/mockserver-core/src/test/java/org/mockserver/mappers/HttpServletRequestToMockServerHttpRequestDecoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/mappers/HttpServletRequestToMockServerHttpRequestDecoderTest.java
@@ -69,7 +69,7 @@ public class HttpServletRequestToMockServerHttpRequestDecoderTest {
             new Cookie("cookieName2", "cookieValue2")
         ), httpRequest.getCookieList());
         assertThat(httpRequest.getLocalAddress(), equalTo("local_addr:1234"));
-        assertThat(httpRequest.getRemoteAddress(), equalTo("remote_addr"));
+        assertThat(httpRequest.getRemoteAddress(), equalTo("remote_addr:80"));
     }
 
     @Test

--- a/mockserver-integration-testing/src/main/java/org/mockserver/testing/integration/mock/AbstractBasicMockingIntegrationTest.java
+++ b/mockserver-integration-testing/src/main/java/org/mockserver/testing/integration/mock/AbstractBasicMockingIntegrationTest.java
@@ -2818,7 +2818,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
                 .withSecure(false)
                 .withSocketAddress("localhost", insecureEchoServer.getPort(), SocketAddress.Scheme.HTTP)
                 .withLocalAddress("127.0.0.1:" + insecureEchoServer.getPort())
-                .withRemoteAddress("127.0.0.1")
+                .withRemoteAddress("127.0.0.1:" + echoServerRequest.getRemoteAddress().split(":")[1])
                 .withBody("some_overridden_body")
         );
         assertEquals(
@@ -2966,7 +2966,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
                 .withSecure(false)
                 .withSocketAddress("localhost", insecureEchoServer.getPort(), SocketAddress.Scheme.HTTP)
                 .withLocalAddress("127.0.0.1:" + insecureEchoServer.getPort())
-                .withRemoteAddress("127.0.0.1")
+                .withRemoteAddress("127.0.0.1:" + echoServerRequest.getRemoteAddress().split(":")[1])
                 .withBody("some_overridden_body")
         );
         assertEquals(
@@ -3047,7 +3047,7 @@ public abstract class AbstractBasicMockingIntegrationTest extends AbstractMockin
                 .withSecure(false)
                 .withSocketAddress("localhost", insecureEchoServer.getPort(), SocketAddress.Scheme.HTTP)
                 .withLocalAddress("127.0.0.1:" + insecureEchoServer.getPort())
-                .withRemoteAddress("127.0.0.1")
+                .withRemoteAddress("127.0.0.1:" + echoServerRequest.getRemoteAddress().split(":")[1])
                 .withBody("some_overridden_body")
         );
         assertEquals(

--- a/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/AbstractExtendedNettyMockingIntegrationTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/netty/integration/mock/AbstractExtendedNettyMockingIntegrationTest.java
@@ -432,7 +432,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                             .withBody("an_example_body_http");
 
                         assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("object_callback")));
                         if (httpRequest.isSecure()) {
                             assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                             assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -518,7 +518,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                         .withBody("an_example_body_http");
 
                     assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("object_callback")));
                     if (httpRequest.isSecure()) {
                         assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                         assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -937,7 +937,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 .forward(
                     httpRequest -> {
                         assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("echo")));
                         if (httpRequest.isSecure()) {
                             assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                             assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -1007,7 +1007,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
             .forward(
                 httpRequest -> {
                     assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("echo")));
                     if (httpRequest.isSecure()) {
                         assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                         assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -1086,7 +1086,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
             .forward(
                 httpRequest -> {
                     assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("/some/path/.*")));
                     if (httpRequest.isSecure()) {
                         assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                         assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -1137,7 +1137,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 )
                 .forward(
                     httpRequest -> {
-                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("echo")));
                         if (httpRequest.isSecure()) {
                             assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                             assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -1218,7 +1218,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
             )
             .forward(
                 httpRequest -> {
-                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("echo")));
                     if (httpRequest.isSecure()) {
                         assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                         assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -1300,7 +1300,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
                 .forward(
                     httpRequest -> {
                         assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                        assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                        assertThat(httpRequest.getRemoteAddress(), startsWith("127.0.0.1:"));
                         if (httpRequest.isSecure()) {
                             assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                             assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));
@@ -1375,7 +1375,7 @@ public abstract class AbstractExtendedNettyMockingIntegrationTest extends Abstra
             .forward(
                 httpRequest -> {
                     assertThat(httpRequest.getLocalAddress(), equalTo("127.0.0.1:" + (httpRequest.isSecure() ? getServerSecurePort() : getServerPort())));
-                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1"));
+                    assertThat(httpRequest.getRemoteAddress(), equalTo("127.0.0.1:" + getRequestTcpPortForPath("echo")));
                     if (httpRequest.isSecure()) {
                         assertThat(httpRequest.getClientCertificateChain().size(), equalTo(2));
                         assertThat(httpRequest.getClientCertificateChain().get(0).getSubjectDistinguishedName(), equalTo("C=UK, ST=England, L=London, O=MockServer, CN=localhost"));

--- a/mockserver-proxy-war/src/test/java/org/mockserver/proxyservlet/ProxyServletTest.java
+++ b/mockserver-proxy-war/src/test/java/org/mockserver/proxyservlet/ProxyServletTest.java
@@ -302,7 +302,7 @@ public class ProxyServletTest {
                 request
                     .withSecure(false)
                     .withLocalAddress("local_address:80")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),
@@ -334,7 +334,7 @@ public class ProxyServletTest {
                 request
                     .withSecure(false)
                     .withLocalAddress("local_address:666")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),
@@ -367,7 +367,7 @@ public class ProxyServletTest {
                 request
                     .withSecure(true)
                     .withLocalAddress("local_address:443")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),
@@ -400,7 +400,7 @@ public class ProxyServletTest {
                 request
                     .withSecure(true)
                     .withLocalAddress("local_address:666")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),

--- a/mockserver-war/src/test/java/org/mockserver/mockservlet/MockServerServletTest.java
+++ b/mockserver-war/src/test/java/org/mockserver/mockservlet/MockServerServletTest.java
@@ -384,7 +384,7 @@ public class MockServerServletTest {
                     .withHeader("Content-Type", APPLICATION_JSON_UTF_8.toString())
                     .withSecure(false)
                     .withLocalAddress("local_address:80")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),
@@ -420,7 +420,7 @@ public class MockServerServletTest {
                     .withHeader("Content-Type", APPLICATION_JSON_UTF_8.toString())
                     .withSecure(false)
                     .withLocalAddress("local_address:666")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),
@@ -457,7 +457,7 @@ public class MockServerServletTest {
                     .withHeader("Content-Type", APPLICATION_JSON_UTF_8.toString())
                     .withSecure(true)
                     .withLocalAddress("local_address:443")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),
@@ -494,7 +494,7 @@ public class MockServerServletTest {
                     .withHeader("Content-Type", APPLICATION_JSON_UTF_8.toString())
                     .withSecure(true)
                     .withLocalAddress("local_address:666")
-                    .withRemoteAddress("localhost")
+                    .withRemoteAddress("localhost:80")
                     .withKeepAlive(true)
             ),
             any(ServletResponseWriter.class),


### PR DESCRIPTION
In our project we need to access the TCP-Port of the client, from which the request originated. Rather then introducing yet another field I propose this more simplified change, still keeping in line with conventions of mockserver-addresses.