### PR TITLE
Issue #1493: Add $import tool for Velocity templates

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngine.java
+++ b/mockserver-core/src/main/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngine.java
@@ -97,6 +97,7 @@ public class VelocityTemplateEngine implements TemplateEngine {
     private ToolContext buildToolManager(VelocityEngine velocityEngine) {
         ToolManager manager = new ToolManager();
 
+        // ToolboxConfiguration for "application" scope
         ToolboxConfiguration applicationToolboxConfiguration = new ToolboxConfiguration();
         applicationToolboxConfiguration.setScope("application");
         ToolConfiguration collectionTool = new ToolConfiguration();
@@ -117,6 +118,8 @@ public class VelocityTemplateEngine implements TemplateEngine {
         ToolConfiguration numberTool = new ToolConfiguration();
         numberTool.setClass(org.apache.velocity.tools.generic.NumberTool.class.getName());
         applicationToolboxConfiguration.addTool(numberTool);
+
+        // ToolboxConfiguration for "request" scope
         ToolboxConfiguration requestToolboxConfiguration = new ToolboxConfiguration();
         requestToolboxConfiguration.setScope("request");
         ToolConfiguration jsonTool = new ToolConfiguration();
@@ -125,6 +128,10 @@ public class VelocityTemplateEngine implements TemplateEngine {
         ToolConfiguration xmlTool = new ToolConfiguration();
         xmlTool.setClass(org.apache.velocity.tools.generic.XmlTool.class.getName());
         requestToolboxConfiguration.addTool(xmlTool);
+        ToolConfiguration importTool = new ToolConfiguration();
+        importTool.setClass(org.apache.velocity.tools.generic.ImportTool.class.getName());
+        requestToolboxConfiguration.addTool(importTool);
+
         XmlFactoryConfiguration xmlFactoryConfiguration = new XmlFactoryConfiguration();
         xmlFactoryConfiguration.addToolbox(applicationToolboxConfiguration);
         xmlFactoryConfiguration.addToolbox(requestToolboxConfiguration);

--- a/mockserver-core/src/test/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngineTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngineTest.java
@@ -21,6 +21,9 @@ import org.mockserver.uuid.UUIDService;
 import org.slf4j.event.Level;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.io.File;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -581,6 +584,96 @@ public class VelocityTemplateEngineTest {
         } finally {
             configuration.velocityDisallowedText(originalVelocityDisallowedText);
         }
+    }
+
+    @Test
+    public void shouldHandleHttpRequestsWithVelocityTemplateWithImportTool() {
+        File testInputFile = new File("testInputFile.txt");
+        String testInputFileContent = "This file content will be part of the response body";
+        try {
+            // given
+            String template = "{" + NEW_LINE +
+                "    'statusCode': 200," + NEW_LINE +
+                "    'body': \"$import.read('testInputFile.txt')\"" + NEW_LINE +
+                "}";
+            HttpRequest request = request()
+                .withPath("/somePath")
+                .withMethod("POST")
+                .withHeader(HOST.toString(), "mock-server.com")
+                .withBody("some_body".getBytes(StandardCharsets.UTF_8));
+
+            try {
+                testInputFile = new File("testInputFile.txt");
+                testInputFile.delete();
+                testInputFile.createNewFile();
+                Files.write(Paths.get(testInputFile.getAbsolutePath()), testInputFileContent.getBytes());
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+
+            // when
+            HttpResponse actualHttpResponse = new VelocityTemplateEngine(mockServerLogger, configuration).executeTemplate(template, request, HttpResponseDTO.class);
+
+            // then
+            assertThat(actualHttpResponse, is(
+                response()
+                    .withStatusCode(200)
+                    .withBody(testInputFileContent)
+            ));
+        } finally {
+            if (testInputFile != null) {
+                testInputFile.delete();
+            }
+        }
+    }
+
+    @Test
+    public void shouldHandleHttpRequestsWithVelocityTemplateWithMathTool() {
+        // given
+        String template = "{" + NEW_LINE +
+            "    'statusCode': 200," + NEW_LINE +
+            "    'body': \"$math.sub('5', '3')\"" + NEW_LINE +
+            "}";
+        HttpRequest request = request()
+            .withPath("/somePath")
+            .withMethod("POST")
+            .withHeader(HOST.toString(), "mock-server.com")
+            .withBody("some_body".getBytes(StandardCharsets.UTF_8));
+
+        // when
+        HttpResponse actualHttpResponse = new VelocityTemplateEngine(mockServerLogger, configuration).executeTemplate(template, request, HttpResponseDTO.class);
+
+        // then
+        assertThat(actualHttpResponse, is(
+            response()
+                .withStatusCode(200)
+                .withBody("2")
+        ));
+    }
+
+    @Test
+    public void shouldHandleHttpRequestsWithVelocityTemplateWithDateTool() {
+        // given
+        String template = "{" + NEW_LINE +
+            "    'statusCode': 200," + NEW_LINE +
+            "    'body': \"$date\"" + NEW_LINE +
+            "}";
+        HttpRequest request = request()
+            .withPath("/somePath")
+            .withMethod("POST")
+            .withHeader(HOST.toString(), "mock-server.com")
+            .withBody("some_body".getBytes(StandardCharsets.UTF_8));
+
+
+        // when
+        HttpResponse actualHttpResponse = new VelocityTemplateEngine(mockServerLogger, configuration).executeTemplate(template, request, HttpResponseDTO.class);
+
+        // then
+        assertThat(actualHttpResponse, is(
+            response()
+                .withStatusCode(200)
+                .withBody(new java.text.SimpleDateFormat("dd MMM yyyy, HH:mm:ss").format(new java.util.Date()))
+        ));
     }
 
     @Test

--- a/mockserver-core/src/test/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngineTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/templates/engine/velocity/VelocityTemplateEngineTest.java
@@ -656,14 +656,18 @@ public class VelocityTemplateEngineTest {
         // given
         String template = "{" + NEW_LINE +
             "    'statusCode': 200," + NEW_LINE +
-            "    'body': \"$date\"" + NEW_LINE +
+            "    'body': \"$date.day $date.month $date.year\"" + NEW_LINE +
             "}";
         HttpRequest request = request()
             .withPath("/somePath")
             .withMethod("POST")
             .withHeader(HOST.toString(), "mock-server.com")
             .withBody("some_body".getBytes(StandardCharsets.UTF_8));
-
+        java.util.Calendar cal = java.util.Calendar.getInstance();
+        cal.setTime(new java.util.Date());
+        int year = cal.get(java.util.Calendar.YEAR);
+        int month = cal.get(java.util.Calendar.MONTH);
+        int day = cal.get(java.util.Calendar.DAY_OF_MONTH);
 
         // when
         HttpResponse actualHttpResponse = new VelocityTemplateEngine(mockServerLogger, configuration).executeTemplate(template, request, HttpResponseDTO.class);
@@ -672,7 +676,7 @@ public class VelocityTemplateEngineTest {
         assertThat(actualHttpResponse, is(
             response()
                 .withStatusCode(200)
-                .withBody(new java.text.SimpleDateFormat("dd MMM yyyy, HH:mm:ss").format(new java.util.Date()))
+                .withBody(day + " " + month + " " + year)
         ));
     }
 


### PR DESCRIPTION
### Issue #:
Issue #1493 

### Issue Description:
Add $import tool for Velocity templates

### Applicable versions:
All existing versions.

### Issue Type:
Enhancement

### Requirement (as mentioned in the Github issue):

- **What you are trying to do**: By using $import.read() in json expectations (with Velocity templates) I could keep my response body contents in files. I recognize I can write Java to do this and I do, but this would greatly simplify what I have to do for that same result.
- **The solution you'd like**: Add org.apache.velocity.tools.view.tools.ImportTool in VelocityTemplateEngine in the static section under ToolManager.
- **Describe alternatives you've considered**: Any way I can use json expectations and pull the response body from files instead of in-lining the contents. I need to respond with XML and everything is difficult to maintain after it is escaped. Files tell the story better and people can understand them right out of the gate.

### About Apache Velocity Import Tool:

- General-purpose text-importing view tool for templates.
- $import is the recommended name of the tool in the Velocity context
- $import.read(): This method takes an arbitrary URL or URI and renders it as a String. This tool can also be used to import local .vm resources without sharing the current velocity-context (as opposed to the #parse directive).
- Examples: $import.read("http://jakarta.apache.org/velocity/tools"), $import.read("/wookie.jsp")

### Changes Added:

- Mockserver code is enhanced to support $import tool provided by Velocity
- Changes here will add org.apache.velocity.tools.generic.ImportTool under ToolboxConfiguration for "request" scope
- This will help in using $import.read() function in velocity templates passed to Mockserver's velocity engine

### Unit Testing:

- Verified that the $import.read() is working fine now, for a simple text file used as input. The test string in the file, is now read by the velocity import tool and is rendered as part of the response body
- Verified the fix in Chrome, Mozilla and Firefox browsers.
- All the test cases for this change is covered in unit test code - VelocityTemplateEngineTest.java. Three new testcases are added - to test $import, $math and $date tools from Velocity. All the tests are executed successfully
- The changes added in the pull request, are applicable only to $import functionality. Ensured that no other code base is affected with this change