### PR TITLE
Condition mounting of libs volume

### DIFF
--- a/helm/mockserver/templates/deployment.yaml
+++ b/helm/mockserver/templates/deployment.yaml
@@ -80,8 +80,10 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /config
+{{- if .Values.app.mountedLibsConfigMapName}}
             - name: libs-volume
               mountPath: /libs
+{{- end}}
 {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -91,10 +93,12 @@ spec:
           configMap:
             name: {{ .Values.app.mountedConfigMapName }}
             optional: true
+{{- if .Values.app.mountedLibsConfigMapName}}
         - name: libs-volume
           configMap:
             name: {{ .Values.app.mountedLibsConfigMapName }}
             optional: true
+{{- end}}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
1) Why is this change necessary?
In some cases, providing callbacks is done by creating a docker image on top of mockerserver ones, adding the callback classes into the /lib older of the docker image.
When dploying with the helm chart, the /lib volume mount is done uncontionnally, overriding what has been done via the docker build, and resulting into a NoClassDefFound exception.

2) How does this change address the issue?
The proposed fix is to simply condition the volume mounting to the presence of field mountedLibsConfigMapName in the Values.app, so it allow the end-user to either provide callbacks via a customer docker, or via pushing the jars into the config map.
(I'm not entering the debate whether configMap should or should not hold jars)

3) What side effects does this change have?
n/a since the the default value remains. It on the end-user to unset it if needed

Tracking Issue: https://github.com/mock-server/mockserver/issues/1571