### PR TITLE
log the response from destination server

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/filters/HopByHopHeaderFilter.java
+++ b/mockserver-core/src/main/java/org/mockserver/filters/HopByHopHeaderFilter.java
@@ -45,7 +45,7 @@ public class HopByHopHeaderFilter {
                     headers.withEntry(header);
                 }
             }
-            HttpRequest clonedRequest = request.clone();
+            HttpRequest clonedRequest = (HttpRequest) request.clone().withLogCorrelationId(request.getLogCorrelationId());
             if (!headers.isEmpty()) {
                 clonedRequest.withHeaders(headers);
             }

--- a/mockserver-core/src/main/java/org/mockserver/httpclient/NettyHttpClient.java
+++ b/mockserver-core/src/main/java/org/mockserver/httpclient/NettyHttpClient.java
@@ -134,6 +134,14 @@ public class NettyHttpClient {
                     if (throwable == null) {
                         if (message != null) {
                             if (forwardProxyClient) {
+                                mockServerLogger.logEvent(
+                                        new LogEntry()
+                                                .setType(LogEntry.LogMessageType.FORWARDED_REQUEST)
+                                                .setLogLevel(Level.INFO)
+                                                .setCorrelationId(httpRequest.getLogCorrelationId())
+                                                .setHttpRequest(httpRequest)
+                                                .setMessageFormat("actual response from destination server: {}")
+                                                .setArguments(message));
                                 httpResponseFuture.complete(hopByHopHeaderFilter.onResponse((HttpResponse) message));
                             } else {
                                 httpResponseFuture.complete((HttpResponse) message);

--- a/mockserver-core/src/main/java/org/mockserver/mock/action/http/HttpOverrideForwardedRequestActionHandler.java
+++ b/mockserver-core/src/main/java/org/mockserver/mock/action/http/HttpOverrideForwardedRequestActionHandler.java
@@ -16,7 +16,7 @@ public class HttpOverrideForwardedRequestActionHandler extends HttpForwardAction
 
     public HttpForwardActionResult handle(final HttpOverrideForwardedRequest httpOverrideForwardedRequest, final HttpRequest request) {
         if (httpOverrideForwardedRequest != null) {
-            HttpRequest requestToSend = request.clone().update(httpOverrideForwardedRequest.getRequestOverride(), httpOverrideForwardedRequest.getRequestModifier());
+            HttpRequest requestToSend = ((HttpRequest) request.clone().withLogCorrelationId(request.getLogCorrelationId())).update(httpOverrideForwardedRequest.getRequestOverride(), httpOverrideForwardedRequest.getRequestModifier());
             return sendRequest(requestToSend, null, httpResponse -> {
                 if (httpResponse == null) {
                     return httpOverrideForwardedRequest.getResponseOverride();


### PR DESCRIPTION
when mockserver is used as proxy, it will
be useful to see the actual response from
the destination server in the Log
messages in the mockserver dashboard

Closes #1650