### PR TITLE
Add documentation about PHP client and Behat

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Docker Hub contains the following artifacts:
 * [mockserver-client-java](http://search.maven.org/#search%7Cga%7C1%7Cmockserver-client-java) - a Java client for both the MockServer and the proxy 
 * [mockserver-client-node](https://www.npmjs.org/package/mockserver-client) - a Node.js and [browser](https://raw.githubusercontent.com/mock-server/mockserver-client-node/mockserver-5.10.0/mockServerClient.js) client for both the MockServer and the proxy
 * [kotest-extensions-kotest](https://github.com/kotest/kotest-extensions-mockserver) - Kotlin Kotest integration with MockServer
+* [mockserver-behat-context](https://github.com/lequipefr/mockserver-behat-context) - Php client and behat context for MockServer
 
 ##### Previous Versions
 | Version         | Date        | Git & Docker Tag / Git Hash                                                                                                                                                                 | Documentation                                | Java API                                                              | REST API                                                                                  |

--- a/jekyll-www.mock-server.com/mock_server/clearing_and_resetting.html
+++ b/jekyll-www.mock-server.com/mock_server/clearing_and_resetting.html
@@ -293,6 +293,18 @@ mockServerClient("localhost", 1080)
   );</code></pre>
         <p>See <a target="_blank" href="https://app.swaggerhub.com/apis/jamesdbloom/mock-server-openapi/{{ site.mockserver_api_version }}#/control/put_reset" target="_blank">REST API</a> for full JSON specification</p>
     </div>
+    <button class="accordion inner">PHP Client</button>
+    <div class="panel">
+    <pre class="prettyprint lang-php code"><code class="code">use Lequipe\MockServer\MockServerClient;
+
+$client = new MockServerClient('http://localhost:1080');
+
+$client->reset();</code></pre>
+    </div>
+    <button class="accordion inner">PHP Behat phrase</button>
+    <div class="panel">
+    <pre class="prettyprint lang-cucumber code"><code class="code">Given I reset mocks</code></pre>
+    </div>
     <button class="accordion inner">REST API</button>
     <div class="panel">
         <pre class="prettyprint code"><code class="code">curl -v -X PUT "http://localhost:1080/mockserver/reset</code></pre>

--- a/jekyll-www.mock-server.com/mock_server/mockserver_clients.html
+++ b/jekyll-www.mock-server.com/mock_server/mockserver_clients.html
@@ -16,6 +16,7 @@ sitemap:
     <li><a href="#rest-api">REST API</a></li>
 	<li><a href="#java-mockserver-client">Java</a></li>
 	<li><a href="#javascript-mockserver-client">JavaScript</a> (both browser API & Node.js module)</li>
+	<li><a href="#php-mockserver-client">PHP</a> (client & Behat)</li>
 </ul>
 
 <p>The following activities are supported:</p>
@@ -66,6 +67,19 @@ sitemap:
 <p>To include the browser based client in an HTML page as follows:</p>
 
 <pre class="prettyprint lang-java code"><code class="code">&lt;script src=&quot;https://raw.githubusercontent.com/mock-server/mockserver-client-node/mockserver-{{ site.mockserver_version }}/mockServerClient.js&quot;&gt;&lt;/script&gt;</code></pre>
+
+<a id="php-mockserver-client" class="anchor" href="#php-mockserver-client">&nbsp;</a>
+
+<h2>PHP Client</h2>
+
+<p>The PHP integration contains a client, and a Behat context for functional tests.</p>
+
+<p>It is accessible:</p>
+
+<ul>
+    <li>on github: <a href="https://github.com/lequipefr/mockserver-behat-context">lequipefr/mockserver-behat-context</a></li>
+    <li>on packagist: <a href="https://packagist.org/packages/lequipefr/mockserver-behat-context">lequipefr/mockserver-behat-context</a></li>
+</ul>
 
 <a id="client-code-examples" class="anchor" href="#client-code-examples">&nbsp;</a>
 
@@ -169,6 +183,34 @@ mockServerClient("localhost", 1080)
     );
 &lt;/script&gt;</code></pre>
         </div>
+        <button class="accordion inner">PHP Client</button>
+        <div class="panel">
+        <pre class="prettyprint lang-php code"><code class="code">use Lequipe\MockServer\MockServerClient;
+use Lequipe\MockServer\Builder\Expectation;
+
+$client = new MockServerClient('http://127.0.0.1:1080');
+$expectation = new Expectation();
+
+$expectation->httpRequest()
+    ->method('get')
+    ->pathWithParameters('/view/cart?cartId=055CA455-1DF7-45BB-8535-4F83E7266092')
+    ->addCookie('session', '4930456C-C718-476F-971F-CB8E047AB349')
+;
+
+$expectation->httpResponse()
+    ->body('some_response_body')
+;
+
+$client->expectation($expectation);</code></pre>
+        </div>
+        <button class="accordion inner">PHP Behat phrase</button>
+        <div class="panel">
+        <pre class="prettyprint lang-cucumber code"><code class="code">Given I will receive the cookie "session" "4930456C-C718-476F-971F-CB8E047AB349"
+And the request "GET" "/view/cart?cartId=055CA455-1DF7-45BB-8535-4F83E7266092" will return:
+    """
+    some_response_body
+    """</code></pre>
+        </div>
         <button class="accordion inner">REST API</button>
         <div class="panel">
         <pre class="prettyprint code"><code class="code">curl -v -X PUT "http://localhost:1080/mockserver/expectation" -d '{
@@ -258,6 +300,26 @@ mockServerClient("localhost", 1080, undefined, true)
     }
   );</code></pre>
         </div>
+        <button class="accordion inner">PHP Client</button>
+        <div class="panel">
+        <pre class="prettyprint lang-php code"><code class="code">use Lequipe\MockServer\MockServerClient;
+use Lequipe\MockServer\Builder\Expectation;
+
+$client = new MockServerClient('https://127.0.0.1:1080');
+$expectation = new Expectation();
+
+$expectation->httpRequest()
+    ->method('get')
+    ->pathWithParameters('/view/cart?cartId=055CA455-1DF7-45BB-8535-4F83E7266092')
+    ->addCookie('session', '4930456C-C718-476F-971F-CB8E047AB349')
+;
+
+$expectation->httpResponse()
+    ->body('some_response_body')
+;
+
+$client->expectation($expectation);</code></pre>
+        </div>
         <button class="accordion inner">REST API</button>
         <div class="panel">
         <pre class="prettyprint code"><code class="code">curl -v -k -X PUT "https://localhost:1080/mockserver/expectation" -d '{
@@ -332,6 +394,26 @@ mockServerClient("localhost", 1080)
       }
     );
 &lt;/script&gt;</code></pre>
+        </div>
+        <button class="accordion inner">PHP Client</button>
+        <div class="panel">
+        <pre class="prettyprint lang-php code"><code class="code">use Lequipe\MockServer\MockServerClient;
+use Lequipe\MockServer\Builder\Verification;
+
+$client = new MockServerClient('http://127.0.0.1:1080');
+$verification = new Verification();
+
+$verification->httpRequest()
+    ->path('/simple')
+;
+
+$verification->exactly(2);
+
+$client->verify($verification);</code></pre>
+        </div>
+        <button class="accordion inner">PHP Behat phrase</button>
+        <div class="panel">
+        <pre class="prettyprint lang-cucumber code"><code class="code">Then the request "GET" "/simple" should have been called exactly 2 times</code></pre>
         </div>
         <button class="accordion inner">REST API</button>
         <div class="panel">
@@ -792,6 +874,18 @@ mockServerClient("localhost", 1080)
       }
     );
 &lt;/script&gt;</code></pre>
+        </div>
+        <button class="accordion inner">PHP Client</button>
+        <div class="panel">
+        <pre class="prettyprint lang-php code"><code class="code">use Lequipe\MockServer\MockServerClient;
+
+$client = new MockServerClient('http://127.0.0.1:1080');
+
+$client->reset();</code></pre>
+        </div>
+        <button class="accordion inner">PHP Behat phrase</button>
+        <div class="panel">
+        <pre class="prettyprint lang-cucumber code"><code class="code">Given I reset mocks</code></pre>
         </div>
         <button class="accordion inner">REST API</button>
         <div class="panel">

--- a/jekyll-www.mock-server.com/where/packagist.html
+++ b/jekyll-www.mock-server.com/where/packagist.html
@@ -1,0 +1,43 @@
+---
+title: Packagist
+layout: page
+pageOrder: 7
+section: 'Where'
+subsection: true
+sitemap:
+  priority: 0.6
+  changefreq: 'monthly'
+  lastmod: 2023-02-23T13:00:00+01:00
+---
+
+<p>
+    There is a PHP integration for mockserver hosted on github:
+    <a href="https://github.com/lequipefr/mockserver-behat-context">lequipefr/mockserver-behat-context</a>.
+</p>
+
+<p>
+    This library provides:
+</p>
+
+<ul>
+    <li>a Behat context for functional testing,</li>
+    <li>a PHP client to send raw expectations as array,</li>
+    <li>and a builder to use autocompleted methods instead of arrays.</li>
+</ul>
+
+<h2>Install from packagist</h2>
+
+<p>
+    The package is hosted on Packagist: <a href="https://packagist.org/packages/lequipefr/mockserver-behat-context">lequipefr/mockserver-behat-context</a>.
+</p>
+
+<p>
+    Install it in your project as a dev dependency:
+</p>
+
+<pre><code class="code">composer require --dev lequipefr/mockserver-behat-context</code></pre>
+
+<p>
+    Follow the README for more information about installation and use:
+    <a href="https://github.com/lequipefr/mockserver-behat-context">README lequipefr/mockserver-behat-context</a>.
+</p>

--- a/mockserver-examples/README.md
+++ b/mockserver-examples/README.md
@@ -14,5 +14,6 @@ The following examples can be found:
 - [node - running mock server, proxying & mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/node_examples/server.js)
 - [curl - mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/curl_examples.md)
 - [json - mocking & verifying scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/json_examples.md)
+- [php - behat phrases](https://github.com/lequipefr/mockserver-behat-context/blob/1.x-dev/docs/behat-phrases.md)
 
 For information on how to use the MockServer please see https://www.mock-server.com


### PR DESCRIPTION
We work with Mockserver for 1 year now, for functional testing mainly.

The library is on github: https://github.com/lequipefr/mockserver-behat-context

Here is the doc updated with references to this PHP and Behat integration, and code examples.