### PR TITLE
Upgrade rhino from 1.7.7.2 to 1.7.14

### DIFF
--- a/mockserver-core/pom.xml
+++ b/mockserver-core/pom.xml
@@ -170,6 +170,12 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
+        <dependency>
+            <!-- upgrade swagger-parser dependency fixing
+                 https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295 -->
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+        </dependency>
 
         <!-- xml -->
         <dependency>


### PR DESCRIPTION
Fixing XML External Entity (XXE) Injection:
https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295

Fixes #1544