### PR TITLE
Removed the jdk14 slf4j bindings from the shaded and no-dependencies jars

### DIFF
--- a/mockserver-client-java/pom.xml
+++ b/mockserver-client-java/pom.xml
@@ -308,7 +308,7 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/slf4j/jul/**</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- exclude manifest signature files -->

--- a/mockserver-integration-testing/pom.xml
+++ b/mockserver-integration-testing/pom.xml
@@ -340,7 +340,7 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/slf4j/jul/**</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- exclude manifest signature files -->

--- a/mockserver-junit-jupiter/pom.xml
+++ b/mockserver-junit-jupiter/pom.xml
@@ -310,7 +310,7 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/slf4j/jul/**</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- exclude manifest signature files -->

--- a/mockserver-junit-rule/pom.xml
+++ b/mockserver-junit-rule/pom.xml
@@ -303,7 +303,7 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/slf4j/jul/**</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- exclude manifest signature files -->

--- a/mockserver-netty/pom.xml
+++ b/mockserver-netty/pom.xml
@@ -397,7 +397,7 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/slf4j/jul/**</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- exclude manifest signature files -->

--- a/mockserver-spring-test-listener/pom.xml
+++ b/mockserver-spring-test-listener/pom.xml
@@ -307,7 +307,7 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>org/slf4j/impl/**</exclude>
+                                        <exclude>org/slf4j/jul/**</exclude>
                                     </excludes>
                                 </filter>
                                 <!-- exclude manifest signature files -->


### PR DESCRIPTION
This fixed #1660

With the update of mock-server from 5.14.0 to 5.15.0, the version of slf4j on which mock-server depends has been raised from 1.7.36 to 2.0.6. At this time, there was a name change in the JDK14 binding package, which was not taken into account in the build configuration.