### PR TITLE
Preserve exact bytes even when encoding is off

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/codec/BodyDecoderEncoder.java
+++ b/mockserver-core/src/main/java/org/mockserver/codec/BodyDecoderEncoder.java
@@ -91,6 +91,7 @@ public class BodyDecoderEncoder {
             } else if (mediaType.isXml()) {
                 return new XmlBody(
                     new String(bodyBytes, mediaType.getCharsetOrDefault()),
+                    bodyBytes,
                     mediaType
                 );
             } else if (mediaType.isString()) {

--- a/mockserver-core/src/test/java/org/mockserver/codec/BodyDecoderEncoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/codec/BodyDecoderEncoderTest.java
@@ -2,14 +2,15 @@ package org.mockserver.codec;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
 import org.junit.Test;
-import org.mockserver.model.Body;
-import org.mockserver.model.BodyWithContentType;
-import org.mockserver.model.MediaType;
-import org.mockserver.model.StringBody;
+import org.mockserver.model.*;
 
 import java.util.Arrays;
 
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_TYPE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
@@ -195,5 +196,18 @@ public class BodyDecoderEncoderTest {
 
         // then
         assertThat(result, is(exact("bytes", MediaType.ANY_VIDEO_TYPE.withCharset(UTF_8))));
+    }
+
+    @Test
+    public void shouldNotAlterBodyForXmlsWithWrongCharset() {
+        // given
+        final byte[] rawContent = {-1, -20, 127, 23, 43, 5, -5, -9};
+        ByteBuf byteBuf = Unpooled.copiedBuffer(rawContent);
+
+        // when
+        BodyWithContentType result = new BodyDecoderEncoder().byteBufToBody(byteBuf, MediaType.XML_UTF_8.toString());
+
+        // then
+        assertThat(result.getRawBytes(), is(rawContent));
     }
 }


### PR DESCRIPTION
We have seen this behavior when decoding MTOM-Request. MTOM is primarily used for non-conformant binary bodies, so the body can NOT be accurately recomposed from the string representation. This is fixed.
This is however a fix with a broader reach. In my opinion mockserver should always strive to alter the messages as little as possible (as it does for every other content-type). This improves on this metric (and judging from the other cases, it was just an oversight).