### PR TITLE
add custom PVC option to helm chart

### DIFF
--- a/helm/mockserver/templates/deployment.yaml
+++ b/helm/mockserver/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
             - name: libs-volume
               mountPath: /libs
 {{- end}}
+{{- if .Values.app.persistentVolumeClaimName}}
+            - name: init-storage
+              mountPath: /init
+{{- end}}
 {{- if .Values.resources }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
@@ -95,11 +99,16 @@ spec:
           configMap:
             name: {{ .Values.app.mountedConfigMapName }}
             optional: true
-{{- if .Values.app.mountedLibsConfigMapName}}
+{{- if .Values.app.mountedLibsConfigMapName }}
         - name: libs-volume
           configMap:
             name: {{ .Values.app.mountedLibsConfigMapName }}
             optional: true
+{{- end}}
+{{- if .Values.app.persistentVolumeClaimName }}
+        - name: init-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.app.persistentVolumeClaimName }}
 {{- end}}
 {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/mockserver/values.yaml
+++ b/helm/mockserver/values.yaml
@@ -7,6 +7,7 @@ app:
   serverPort: "1080"
   mountedConfigMapName: "mockserver-config"
   mountedLibsConfigMapName: "mockserver-config"
+  persistentVolumeClaimName:
   propertiesFileName: "mockserver.properties"
   readOnlyRootFilesystem: false
   serviceAccountName: default


### PR DESCRIPTION
Relates to https://github.com/mock-server/mockserver/issues/1779

This allows users to persist Expectation across pod restarts on Kubernetes. 

With this change, users can create their own PVC and attach it to the pod using the Helm chart values.