### PR TITLE
Fix path parameter invalid pattern - issues: #1524, 1505

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/codec/PathParametersDecoder.java
+++ b/mockserver-core/src/main/java/org/mockserver/codec/PathParametersDecoder.java
@@ -67,7 +67,7 @@ public class PathParametersDecoder {
     }
 
     public Parameters extractPathParameters(HttpRequest matcher, HttpRequest matched) {
-        Parameters parsedParameters = matched.getPathParameters() != null ? matched.getPathParameters() : new Parameters();
+        Parameters parsedParameters = matched.getPathParameters() != null ? matched.getPathParameters().clone() : new Parameters();
         if (matcher.getPathParameters() != null && !matcher.getPathParameters().isEmpty()) {
             String[] matcherPathParts = getPathParts(matcher.getPath());
             String[] matchedPathParts = getPathParts(matched.getPath());

--- a/mockserver-core/src/test/java/org/mockserver/codec/PathParametersDecoderTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/codec/PathParametersDecoderTest.java
@@ -2,7 +2,9 @@ package org.mockserver.codec;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.Test;
+import org.mockserver.model.HttpRequest;
 import org.mockserver.model.Parameter;
+import org.mockserver.model.Parameters;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -10,6 +12,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.NottableString.string;
@@ -875,6 +878,19 @@ public class PathParametersDecoderTest {
                 param("name", "bob;name=bill;name=tony")
             )
         );
+    }
+
+    @Test
+    public void shouldNotAlterRequestPathParametersDuringExtraction() {
+        HttpRequest originalRequest = request()
+            .withPath("/path/{pathId}/subPath")
+            .withPathParameters(param("pathId", "(.+)"));
+        HttpRequest clonedRequest = originalRequest.clone();
+
+        Parameters parameters = new PathParametersDecoder().extractPathParameters(originalRequest, clonedRequest);
+
+        assertThat(parameters, equalTo(new Parameters(param("pathId", "(.+)", "{pathId}"))));
+        assertThat(clonedRequest, equalTo(originalRequest));
     }
 
     void shouldRetrieveParameters(String matcherPath, Parameter[] parameter, String requestPath, List<Parameter> expected) {


### PR DESCRIPTION
Fixes issues:
- https://github.com/mock-server/mockserver/issues/1505
- https://github.com/mock-server/mockserver/issues/1524

During verification, `HttpRequestPropertiesMatcher` calls `matches` function to verify the RequestDefinition against itself - resulting the same behaviour as can be seen in newly added test, that the path parameter name will be added also as a value to the MultiValueMap. 
With this modification `PathParametersDecoder#extractPathParameters` method will not alter the stored RequestDefinition, and will not result the invalid Pattern matching for path parameter name Strings, which are not indended to be valid regex patterns.