### PR TITLE
Bugfix/Changed JVM_OPTIONS to JAVA_TOOL_OPTIONS

### DIFF
--- a/helm/mockserver/templates/deployment.yaml
+++ b/helm/mockserver/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
               value: {{ .Values.app.proxyRemotePort | quote }}
 {{- end }}
 {{- if .Values.app.jvmOptions }}
-            - name: JVM_OPTIONS
+            - name: JAVA_TOOL_OPTIONS
               value: {{ .Values.app.jvmOptions | quote }}
 {{- end }}
 {{- if .Values.app.mountConfigMap }}


### PR DESCRIPTION
Issue: Deploying Mockserver's Helm chart with app.jvmOptions was not working (Java was ignoring the flags).

Solution: Use JAVA_TOOL_OPTIONS instead of JVM_OPTIONS. (**[Documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/envvars002.html)**)