### PR TITLE
Fixed test failures caused by non-deterministic order of style map

### DIFF
--- a/mockserver-netty/src/main/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializer.java
@@ -93,6 +93,7 @@ public class DashboardLogEntryDTOSerializer extends StdSerializer<DashboardLogEn
 
     public Map<String, String> logStyle(DashboardLogEntryDTO logEntry) {
         Map<String, String> style = new LinkedHashMap<>();
+        style.put("style.whiteSpace", "");
         style.put("paddingBottom", "4px");
         style.put("whiteSpace", "nowrap");
         style.put("overflow", "auto");
@@ -170,6 +171,9 @@ public class DashboardLogEntryDTOSerializer extends StdSerializer<DashboardLogEn
                 break;
             default:
                 style.put("color", "rgb(201, 125, 240)");
+        }
+        if (style.get("style.whiteSpace").isEmpty()) {
+            style.remove("style.whiteSpace");
         }
         style.put("paddingTop", "4px");
         return style;

--- a/mockserver-netty/src/main/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializer.java
+++ b/mockserver-netty/src/main/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializer.java
@@ -10,6 +10,7 @@ import org.mockserver.model.NottableString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -91,8 +92,7 @@ public class DashboardLogEntryDTOSerializer extends StdSerializer<DashboardLogEn
     }
 
     public Map<String, String> logStyle(DashboardLogEntryDTO logEntry) {
-        Map<String, String> style = new HashMap<>();
-        style.put("paddingTop", "4px");
+        Map<String, String> style = new LinkedHashMap<>();
         style.put("paddingBottom", "4px");
         style.put("whiteSpace", "nowrap");
         style.put("overflow", "auto");
@@ -171,6 +171,7 @@ public class DashboardLogEntryDTOSerializer extends StdSerializer<DashboardLogEn
             default:
                 style.put("color", "rgb(201, 125, 240)");
         }
+        style.put("paddingTop", "4px");
         return style;
     }
 }


### PR DESCRIPTION
Created this PR to fix 19 flaky tests listed as follows:

1. [shouldSerialiseEventWithMultiLineStringArgumentAsAll](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L145)
2. [shouldSerialiseEventWithObjectArgumentAsAll](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L417)
3. [shouldSerialiseEventWithMultiLineString](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L572)
4. [shouldSerialiseEventWithBecauseArgumentNotMatching](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L310)
5. [shouldSerialiseEventWithBecauseArgumentAsFirst](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L198)
6. [shouldSerialiseEventWithMultiLineStringArgumentAsFirst](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L94)
7. [shouldSerialiseEventWithTooFewArguments](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L520)
8. [shouldSerialiseBinaryForward](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L659)
9. [shouldSerialiseEventWithObjectArgumentAsFirst](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L366)
10. [shouldSerialiseEventWithTooManyArguments](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L470)
11. [shouldSerialiseEventWithBecauseArgumentAsLast](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L254)
12. [shouldSerialiseEventWithSingleLineStringArgument](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L45)
13. [shouldSerialiseEventWithThrowable](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L621)
14. [shouldSerialiseMessageWithException](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/DashboardWebSocketHandlerTest.java#L512)
15. [shouldSerialiseRollUpEventsWithSameCorrelationIdAndNotWarpEventsWithUniqueCorrelationId](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/DashboardWebSocketHandlerTest.java#L739)
16. [shouldSerialiseEventsWithRequest](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/DashboardWebSocketHandlerTest.java#L587)
17. [shouldSerialiseEventsWithoutFields](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/DashboardWebSocketHandlerTest.java#L852)
18. [shouldSerialiseGroupWithSingleEvent](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOGroupSerializerTest.java#L44)
19. [shouldSerialiseGroupWithMultipleEvents](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOGroupSerializerTest.java#L95)

-----------------

1. How were these test identified as flaky?
These tests were identified as flaky by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

2. What was the error?
The error was caused by non-deterministic ordering of keys in the style map, which is used to create a part of the `json` variable structure in the tests ([here](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/test/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializerTest.java#L162)). The tests were asserting the exact order of keys in the generated JSON, including properties like paddingBottom, whiteSpace, overflow, color, and paddingTop. Since the implementation was using a HashMap to create the [style map](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/main/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializer.java#L94), the order of keys was not guaranteed, leading to different orders during test execution.

**Common Error among all the tests mentioned below - jumbled ordering of style map's keys in the json:**
```
Expected: is "{\n  \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_log\",\n  \"value\" : {\n    \"description\" : \"07-01 00:51:18.216 TEMPLATE_GENERATED \",\n    \"style\" : {\n      \"paddingBottom\" : \"4px\",\n      \"whiteSpace\" : \"nowrap\",\n      \"overflow\" : \"auto\",\n      \"color\" : \"rgb(241, 186, 27)\",\n      \"paddingTop\" : \"4px\"\n    },\n    \"messageParts\" : [ {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_0msg\",\n      \"value\" : \"some random\"\n    }, {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_0arg\",\n      \"multiline\" : true,\n      \"argument\" : true,\n      \"value\" : [ \"line one_one\", \"line one_two\", \"line one_three\" ]\n    }, {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_1msg\",\n      \"value\" : \"formatted string\"\n    }, {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_1arg\",\n      \"multiline\" : true,\n      \"argument\" : true,\n      \"value\" : [ \"line two_one\", \"line two_two\", \"line two_three\" ]\n    } ]\n  }\n}"
     but: was "{\n  \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_log\",\n  \"value\" : {\n    \"description\" : \"07-01 00:51:18.216 TEMPLATE_GENERATED \",\n    \"style\" : {\n      \"whiteSpace\" : \"nowrap\",\n      \"color\" : \"rgb(241, 186, 27)\",\n      \"paddingTop\" : \"4px\",\n      \"paddingBottom\" : \"4px\",\n      \"overflow\" : \"auto\"\n    },\n    \"messageParts\" : [ {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_0msg\",\n      \"value\" : \"some random\"\n    }, {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_0arg\",\n      \"multiline\" : true,\n      \"argument\" : true,\n      \"value\" : [ \"line one_one\", \"line one_two\", \"line one_three\" ]\n    }, {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_1msg\",\n      \"value\" : \"formatted string\"\n    }, {\n      \"key\" : \"854d6862-2ee2-4251-9586-b259f854a402_1arg\",\n      \"multiline\" : true,\n      \"argument\" : true,\n      \"value\" : [ \"line two_one\", \"line two_two\", \"line two_three\" ]\n    } ]\n  }\n}"
```
3. What is the fix?
To address the non-deterministic order of keys, I replaced the usage of HashMap with LinkedHashMap when creating the style map. Unlike HashMap, LinkedHashMap preserves the order of keys based on their insertion order. By explicitly ordering the keys in the style map according to the expected order, we can ensure consistent ordering during each test run. This PR proposes changing HashMap to LinkedHashMap [here](https://github.com/mock-server/mockserver/blob/master/mockserver-netty/src/main/java/org/mockserver/dashboard/serializers/DashboardLogEntryDTOSerializer.java#L94) and adding elements to style map in the expected order to fix all the listed tests.

---------------------
You can run the following commands to run the 19 tests using NonDex tool respectively:
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithMultiLineStringArgumentAsAll
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithObjectArgumentAsAll
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithMultiLineString
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithBecauseArgumentNotMatching 
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithBecauseArgumentAsFirst
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithMultiLineStringArgumentAsFirst
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithTooFewArguments
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseBinaryForward
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithObjectArgumentAsFirst
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithTooManyArguments
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithBecauseArgumentAsLast
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithSingleLineStringArgument
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOSerializerTest#shouldSerialiseEventWithThrowable
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.DashboardWebSocketHandlerTest#shouldSerialiseMessageWithException
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.DashboardWebSocketHandlerTest#shouldSerialiseRollUpEventsWithSameCorrelationIdAndNotWarpEventsWithUniqueCorrelationId
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.DashboardWebSocketHandlerTest#shouldSerialiseEventsWithRequest
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.DashboardWebSocketHandlerTest#shouldSerialiseEventsWithoutFields
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOGroupSerializerTest#shouldSerialiseGroupWithSingleEvent
```
```
mvn -pl mockserver-netty edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.mockserver.dashboard.serializers.DashboardLogEntryDTOGroupSerializerTest#shouldSerialiseGroupWithMultipleEvents
```

Test Environment:
```
java version 11.0.19
Apache Maven 3.9.5
```
Kindly let me know if this fix is acceptable.
Thank you