### PR TITLE
Support ipv6 adresses

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -1705,7 +1705,7 @@ public class ConfigurationProperties {
         InetSocketAddress inetSocketAddress = null;
         String proxy = readPropertyHierarchically(PROPERTIES, key, environmentVariableKey, "");
         if (isNotBlank(proxy)) {
-            String[] proxyParts = proxy.split(":");
+            String[] proxyParts = org.mockserver.model.HttpRequest.splitHostPort(proxy);
             if (proxyParts.length > 1) {
                 try {
                     inetSocketAddress = new InetSocketAddress(proxyParts[0], Integer.parseInt(proxyParts[1]));

--- a/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
+++ b/mockserver-core/src/main/java/org/mockserver/model/HttpRequest.java
@@ -215,12 +215,13 @@ public class HttpRequest extends RequestDefinition implements HttpMessage<HttpRe
     public static String[] splitHostPort(String hostPort) {
         boolean isIpV6 = hostPort.matches("\\[(.*)].*");
         if (isIpV6) {
-            int endOfHost = hostPort.indexOf(']') + 1;
+            int endOfHost = hostPort.indexOf(']');
+            String host = hostPort.substring(1, endOfHost);  // Strip [ and ]
             int startOfPort = hostPort.indexOf(':', endOfHost);
             if (startOfPort > 0) {
-                return new String[] { hostPort.substring(0, endOfHost), hostPort.substring(startOfPort + 1) };
+                return new String[] { host, hostPort.substring(startOfPort + 1) };
             } else {
-                return new String[] {hostPort};
+                return new String[] { host };
             }
         } else {
             return hostPort.split(":");

--- a/mockserver-core/src/main/java/org/mockserver/proxyconfiguration/ProxyConfiguration.java
+++ b/mockserver-core/src/main/java/org/mockserver/proxyconfiguration/ProxyConfiguration.java
@@ -68,9 +68,9 @@ public class ProxyConfiguration extends ObjectWithJsonToString {
     }
 
     public static ProxyConfiguration proxyConfiguration(Type type, String address, String username, String password) {
-        String[] addressParts = address.split(":");
+        String[] addressParts = org.mockserver.model.HttpRequest.splitHostPort(address);
         if (addressParts.length != 2) {
-            throw new IllegalArgumentException("Proxy address must be in the format <host>:<ip>, for example 127.0.0.1:9090 or localhost:9090");
+            throw new IllegalArgumentException("Proxy address must be in the format <host>:<port>, for example 127.0.0.1:9090, localhost:9090, or [::1]:9090");
         } else {
             try {
                 return proxyConfiguration(type, new InetSocketAddress(addressParts[0], Integer.parseInt(addressParts[1])), username, password);

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
@@ -380,7 +380,7 @@ public class HttpRequestTest {
     }
 
     @Test
-    void parsesIpv6AndIpv4HostPort() {
+    public void parsesIpv6AndIpv4HostPort() {
         String[] hostParts = HttpRequest.splitHostPort("[::1]:32890");
         assertEquals("[::1]", hostParts[0]);
         assertEquals("32890", hostParts[1]);

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
@@ -379,4 +379,22 @@ public class HttpRequestTest {
         ));
     }
 
+    @Test
+    void parsesIpv6AndIpv4HostPort() {
+        String[] hostParts = HttpRequest.splitHostPort("[::1]:32890");
+        assertEquals("[::1]", hostParts[0]);
+        assertEquals("32890", hostParts[1]);
+        hostParts = HttpRequest.splitHostPort("localhost:32890");
+        assertEquals("localhost", hostParts[0]);
+        assertEquals("32890", hostParts[1]);
+        hostParts = HttpRequest.splitHostPort("127.0.0.1:32890");
+        assertEquals("127.0.0.1", hostParts[0]);
+        assertEquals("32890", hostParts[1]);
+        hostParts = HttpRequest.splitHostPort("127.0.0.1");
+        assertEquals("127.0.0.1", hostParts[0]);
+        assertEquals(1, hostParts.length);
+        hostParts = HttpRequest.splitHostPort("[::1]");
+        assertEquals("[::1]", hostParts[0]);
+        assertEquals(1, hostParts.length);
+    }
 }

--- a/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/model/HttpRequestTest.java
@@ -3,6 +3,7 @@ package org.mockserver.model;
 import junit.framework.TestCase;
 import org.junit.Test;
 
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -381,20 +382,74 @@ public class HttpRequestTest {
 
     @Test
     public void parsesIpv6AndIpv4HostPort() {
+        // IPv6 with port - brackets should be stripped
         String[] hostParts = HttpRequest.splitHostPort("[::1]:32890");
-        assertEquals("[::1]", hostParts[0]);
+        assertEquals("::1", hostParts[0]);
         assertEquals("32890", hostParts[1]);
+        
+        // Hostname with port
         hostParts = HttpRequest.splitHostPort("localhost:32890");
         assertEquals("localhost", hostParts[0]);
         assertEquals("32890", hostParts[1]);
+        
+        // IPv4 with port
         hostParts = HttpRequest.splitHostPort("127.0.0.1:32890");
         assertEquals("127.0.0.1", hostParts[0]);
         assertEquals("32890", hostParts[1]);
+        
+        // IPv4 without port
         hostParts = HttpRequest.splitHostPort("127.0.0.1");
         assertEquals("127.0.0.1", hostParts[0]);
         assertEquals(1, hostParts.length);
+        
+        // IPv6 without port - brackets should be stripped
         hostParts = HttpRequest.splitHostPort("[::1]");
-        assertEquals("[::1]", hostParts[0]);
+        assertEquals("::1", hostParts[0]);
         assertEquals(1, hostParts.length);
+        
+        // Full IPv6 address with port
+        hostParts = HttpRequest.splitHostPort("[2001:db8::1]:8080");
+        assertEquals("2001:db8::1", hostParts[0]);
+        assertEquals("8080", hostParts[1]);
+    }
+
+    @Test
+    public void shouldParseIpv6SocketAddressFromHostHeader() {
+        // Given
+        HttpRequest request = request()
+            .withHeader("Host", "[::1]:8080");
+        
+        // When
+        InetSocketAddress socketAddress = request.socketAddressFromHostHeader();
+        
+        // Then
+        assertEquals("0:0:0:0:0:0:0:1", socketAddress.getAddress().getHostAddress());
+        assertEquals(8080, socketAddress.getPort());
+    }
+
+    @Test
+    public void shouldParseIpv6SocketAddressWithoutPort() {
+        // Given
+        HttpRequest request = request()
+            .withSecure(true)
+            .withHeader("Host", "[2001:db8::1]");
+        
+        // When
+        InetSocketAddress socketAddress = request.socketAddressFromHostHeader();
+        
+        // Then
+        assertEquals("2001:db8:0:0:0:0:0:1", socketAddress.getAddress().getHostAddress());
+        assertEquals(443, socketAddress.getPort());  // Default HTTPS port
+    }
+
+    @Test
+    public void shouldParseIpv6WithSocketAddress() {
+        // Given - When
+        HttpRequest request = request()
+            .withSocketAddress(false, "[::1]:9090", null);
+        
+        // Then
+        assertEquals("::1", request.getSocketAddress().getHost());
+        assertEquals(Integer.valueOf(9090), request.getSocketAddress().getPort());
     }
 }


### PR DESCRIPTION
When running some tests with testcontainers and docker in wsl - my ipv6 adress to the container failed parsing. This change fixed the issue by detecting ipv6 adresses and parsing them better. 