### PR TITLE
disable LRUCache "allCaches" feature by default

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/cache/LRUCache.java
+++ b/mockserver-core/src/main/java/org/mockserver/cache/LRUCache.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 @SuppressWarnings("unused")
 public class LRUCache<K, V> {
 
-    private static boolean allCachesEnabled = true;
+    private static boolean allCachesEnabled = false;
     private static int maxSizeOverride = 0;
     private static final Set<LRUCache<?, ?>> allCaches = Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
     private final long ttlInMillis;
@@ -27,7 +27,9 @@ public class LRUCache<K, V> {
         this.map = new ConcurrentHashMap<>(maxSize);
         this.queue = new ConcurrentLinkedQueue<>();
         this.ttlInMillis = ttlInMillis;
-        LRUCache.allCaches.add(this);
+        if (allCachesEnabled) {
+            allCaches.add(this);
+        }
     }
 
     public static void allCachesEnabled(boolean enabled) {

--- a/mockserver-core/src/test/java/org/mockserver/cache/LRUCacheTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/cache/LRUCacheTest.java
@@ -1,5 +1,7 @@
 package org.mockserver.cache;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockserver.logging.MockServerLogger;
 
@@ -12,6 +14,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class LRUCacheTest {
 
     private final MockServerLogger mockServerLogger = new MockServerLogger(LRUCacheTest.class);
+
+    @Before
+    public void setUp() {
+        LRUCache.allCachesEnabled(true);
+    }
+
+    @After
+    public void tearDown() {
+        LRUCache.allCachesEnabled(false);
+    }
 
     @Test
     public void shouldReturnCachedObjects() {
@@ -30,21 +42,17 @@ public class LRUCacheTest {
 
     @Test
     public void shouldNotCacheIfGloballyDisabled() {
-        try {
-            // given
-            LRUCache.allCachesEnabled(false);
-            LRUCache<String, Object> lruCache = new LRUCache<>(mockServerLogger, 5, MINUTES.toMillis(10));
+        // given
+        LRUCache.allCachesEnabled(false);
+        LRUCache<String, Object> lruCache = new LRUCache<>(mockServerLogger, 5, MINUTES.toMillis(10));
 
-            // when
-            lruCache.put("one", "a");
-            lruCache.put("two", "b");
+        // when
+        lruCache.put("one", "a");
+        lruCache.put("two", "b");
 
-            // then
-            assertThat(lruCache.get("one"), nullValue());
-            assertThat(lruCache.get("two"), nullValue());
-        } finally {
-            LRUCache.allCachesEnabled(true);
-        }
+        // then
+        assertThat(lruCache.get("one"), nullValue());
+        assertThat(lruCache.get("two"), nullValue());
     }
 
     @Test


### PR DESCRIPTION
@eric6iese @jamesdbloom
it's totally unexpected hidden feature which causes memory leaks.

I believe most users don't even know about existence of such a feature. And I don't see any usages of this feature in MockServer own code as well.

P.S. `allCaches` was improved in https://github.com/mock-server/mockserver/pull/1648/files, but I suggest to improve it even more. :) 
