### PR TITLE
Docs: fix Node.js link, add link to Docker Compose examples

### DIFF
--- a/mockserver-examples/README.md
+++ b/mockserver-examples/README.md
@@ -11,7 +11,8 @@ The following examples can be found:
   - [Jetty](https://github.com/mock-server/mockserver/tree/master/mockserver-examples/src/main/java/org/mockserver/examples/proxy/service/jettyclient)
   - [Spring Rest Template](https://github.com/mock-server/mockserver/tree/master/mockserver-examples/src/main/java/org/mockserver/examples/proxy/service/springresttemplate) 
   - [Spring Web Client](https://github.com/mock-server/mockserver/tree/master/mockserver-examples/src/main/java/org/mockserver/examples/proxy/service/springwebclient)
-- [node - running mock server, proxying & mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/node_examples/server.js)
+- [node - client, mocking and verifying scenarios](https://github.com/mock-server/mockserver/tree/master/mockserver-examples/node_examples)
+  - [running mock server, proxying & mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/node_examples/run_mockserver_and_add_expectations/server.js)
 - [curl - mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/curl_examples.md)
 - [json - mocking & verifying scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/json_examples.md)
 

--- a/mockserver-examples/README.md
+++ b/mockserver-examples/README.md
@@ -15,5 +15,6 @@ The following examples can be found:
   - [running mock server, proxying & mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/node_examples/run_mockserver_and_add_expectations/server.js)
 - [curl - mocking scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/curl_examples.md)
 - [json - mocking & verifying scenarios](https://github.com/mock-server/mockserver/blob/master/mockserver-examples/json_examples.md)
+- [docker compose - ways of configuring and running mock server](https://github.com/mock-server/mockserver/tree/master/mockserver-examples/docker_compose_examples)
 
 For information on how to use the MockServer please see https://www.mock-server.com


### PR DESCRIPTION
💁 While browsing the documentation for this excellent project, I came across a broken link and made these changes. 

These changes:
* Fix
  *  a broken link to a previous Node.js example (removed in 5104722e3d5bffaf20556e03e77cfe4bf2a2cfa1, did I link to a suitable replacement?)
* Add
  * A link to the directory of Node.js examples
  * A link to the directory of Docker Compose configuration examples