### PR TITLE
Fix CVE-2025-55163 & GHSA-xpw8-rcwv-8f8p Security Vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,7 @@
                 <!-- Conflicting versions in swagger-parser -->
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
+                <version>2.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <slf4j.version>2.0.6</slf4j.version>
         <jackson.version>2.14.2</jackson.version>
         <velocity.version>2.3</velocity.version>
-        <netty.version>4.1.89.Final</netty.version>
+        <netty.version>4.1.124</netty.version>
         <httpcomponents.version>4.4.1</httpcomponents.version>
         <bouncycastle.version>1.72</bouncycastle.version>
         <!-- highest spring version is 5.3 due to Java 1.8 version -->


### PR DESCRIPTION
Vulnerabilities

===============

  CVE                    Severity    CVSS    CVE Introduced From Package    Package Version    Fixed In Version    Grace period ends on

  ---                    --------    ----    ---------------------------    ---------------    ----------------    --------------------

  CVE-2025-55163         high        8.2     io.netty:netty-codec-http2     4.1.86.Final       4.1.124             NA

  GHSA-xpw8-rcwv-8f8p    high        7.5     io.netty:netty-codec-http2     4.1.86.Final       4.1.100             NA