### PR TITLE
not only filter out optional strings but also notted strings

### DIFF
--- a/mockserver-core/src/main/java/org/mockserver/collections/ImmutableEntry.java
+++ b/mockserver-core/src/main/java/org/mockserver/collections/ImmutableEntry.java
@@ -45,6 +45,10 @@ public class ImmutableEntry extends Pair<NottableString, NottableString> impleme
         return !isOptional();
     }
 
+    public boolean isNotNotted() {
+        return !isNotted();
+    }
+
     @Override
     public NottableString getLeft() {
         return key;

--- a/mockserver-core/src/main/java/org/mockserver/collections/SubSetMatcher.java
+++ b/mockserver-core/src/main/java/org/mockserver/collections/SubSetMatcher.java
@@ -28,9 +28,12 @@ public class SubSetMatcher {
         }
 
         if (result) {
-            long subsetNonOptionalSize = subset.stream().filter(ImmutableEntry::isNotOptional).count();
+            long subsetRequiredSize = subset.stream()
+                .filter(ImmutableEntry::isNotOptional)
+                .filter(ImmutableEntry::isNotNotted)
+                .count();
             // this prevents multiple items in the subset from being matched by a single item in the superset
-            result = matchingIndexes.size() >= subsetNonOptionalSize;
+            result = matchingIndexes.size() >= subsetRequiredSize;
         }
         return result;
     }

--- a/mockserver-core/src/test/java/org/mockserver/collections/SubSetMatcherTest.java
+++ b/mockserver-core/src/test/java/org/mockserver/collections/SubSetMatcherTest.java
@@ -313,4 +313,74 @@ public class SubSetMatcherTest {
         );
     }
 
+    @Test
+    public void shouldContainSubsetWithPositiveAndNottedKeys() {
+        // Issue #1974: notted parameters should not count toward required matches
+        // Expectation: name=John AND NOT age
+        // Request: name=John (no age parameter)
+        // Should match because: 1 positive match (name) >= 1 required (name), and age is not present
+        assertTrue(containsSubset(null, null, regexStringMatcher,
+            Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John"),
+                new ImmutableEntry(regexStringMatcher, "!age", ".*")
+            ),
+            new ArrayList<>(Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John")
+            )))
+        );
+    }
+
+    @Test
+    public void shouldContainSubsetWithMultiplePositiveAndNottedKeys() {
+        // Expectation: name=John AND city=London AND NOT age AND NOT country
+        // Request: name=John, city=London (no age or country)
+        // Should match because: 2 positive matches >= 2 required, and age/country not present
+        assertTrue(containsSubset(null, null, regexStringMatcher,
+            Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John"),
+                new ImmutableEntry(regexStringMatcher, "city", "London"),
+                new ImmutableEntry(regexStringMatcher, "!age", ".*"),
+                new ImmutableEntry(regexStringMatcher, "!country", ".*")
+            ),
+            new ArrayList<>(Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John"),
+                new ImmutableEntry(regexStringMatcher, "city", "London")
+            )))
+        );
+    }
+
+    @Test
+    public void shouldContainSubsetWithOptionalAndNottedKeys() {
+        // Expectation: name=John AND ?age AND NOT country
+        // Request: name=John (no age or country)
+        // Should match: 1 positive match >= 1 required, age optional, country not present
+        assertTrue(containsSubset(null, null, regexStringMatcher,
+            Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John"),
+                new ImmutableEntry(regexStringMatcher, "?age", ".*"),
+                new ImmutableEntry(regexStringMatcher, "!country", ".*")
+            ),
+            new ArrayList<>(Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John")
+            )))
+        );
+    }
+
+    @Test
+    public void shouldNotContainSubsetWhenNottedKeyIsPresent() {
+        // Expectation: name=John AND NOT age
+        // Request: name=John, age=25
+        // Should NOT match because age is present (notted key found)
+        assertFalse(containsSubset(null, null, regexStringMatcher,
+            Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John"),
+                new ImmutableEntry(regexStringMatcher, "!age", ".*")
+            ),
+            new ArrayList<>(Arrays.asList(
+                new ImmutableEntry(regexStringMatcher, "name", "John"),
+                new ImmutableEntry(regexStringMatcher, "age", "25")
+            )))
+        );
+    }
+
 }


### PR DESCRIPTION
fixes https://github.com/mock-server/mockserver/issues/1974

Some small additions to also consider.
Maybe add some tests that check if now mixing different type of strings (nottable & optional & ‘normal’) works correctly.

Also what I find kind of strange is that here https://github.com/mock-server/mockserver/blob/master/mockserver-core/src/main/java/org/mockserver/collections/ImmutableEntry.java#L36-L42 isOptional only checks that key is optional. But isNotted not only checks the key but also that the value is not notted. Why the difference?