### PR TITLE
fix: Java 11 compatibility and flaky test issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "com.puppycrawl.tools:checkstyle"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "net.javacrumbs.json-unit:json-unit-core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.jayway.jsonpath:json-path"
+        update-types: ["version-update:semver-major"]
       # Block servlet namespace migration
       - dependency-name: "javax.servlet:*"
         update-types: ["version-update:semver-major"]

--- a/mockserver-core/src/main/java/org/mockserver/authentication/jwt/CustomJWTClaimsVerifier.java
+++ b/mockserver-core/src/main/java/org/mockserver/authentication/jwt/CustomJWTClaimsVerifier.java
@@ -34,18 +34,6 @@ public class CustomJWTClaimsVerifier extends DefaultJWTClaimsVerifier<SecurityCo
             }
         }
 
-        if (exactMatchClaims != null && !exactMatchClaims.getClaims().isEmpty()) {
-            for (Map.Entry<String, Object> entry : exactMatchClaims.getClaims().entrySet()) {
-                String claimName = entry.getKey();
-                Object expectedValue = entry.getValue();
-                Object actualValue = claimsSet.getClaim(claimName);
-                
-                if (!expectedValue.equals(actualValue)) {
-                    throw new BadJWTException("JWT " + claimName + " claim has value " + actualValue + ", must be " + expectedValue);
-                }
-            }
-        }
-
         if (requiredClaims != null && !requiredClaims.isEmpty()) {
             Set<String> missingClaims = new HashSet<>();
             for (String requiredClaim : requiredClaims) {
@@ -57,6 +45,18 @@ public class CustomJWTClaimsVerifier extends DefaultJWTClaimsVerifier<SecurityCo
                 List<String> sorted = new ArrayList<>(missingClaims);
                 sorted.sort(String::compareTo);
                 throw new BadJWTException("JWT missing required claims: " + sorted);
+            }
+        }
+
+        if (exactMatchClaims != null && !exactMatchClaims.getClaims().isEmpty()) {
+            for (Map.Entry<String, Object> entry : exactMatchClaims.getClaims().entrySet()) {
+                String claimName = entry.getKey();
+                Object expectedValue = entry.getValue();
+                Object actualValue = claimsSet.getClaim(claimName);
+                
+                if (!expectedValue.equals(actualValue)) {
+                    throw new BadJWTException("JWT " + claimName + " claim has value " + actualValue + ", must be " + expectedValue);
+                }
             }
         }
 

--- a/mockserver-core/src/main/java/org/mockserver/authentication/jwt/CustomJWTClaimsVerifier.java
+++ b/mockserver-core/src/main/java/org/mockserver/authentication/jwt/CustomJWTClaimsVerifier.java
@@ -1,0 +1,65 @@
+package org.mockserver.authentication.jwt;
+
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class CustomJWTClaimsVerifier extends DefaultJWTClaimsVerifier<SecurityContext> {
+
+    private final String expectedAudience;
+    private final JWTClaimsSet exactMatchClaims;
+    private final Set<String> requiredClaims;
+
+    public CustomJWTClaimsVerifier(String expectedAudience, JWTClaimsSet exactMatchClaims, Set<String> requiredClaims) {
+        super(expectedAudience, exactMatchClaims, requiredClaims);
+        this.expectedAudience = expectedAudience;
+        this.exactMatchClaims = exactMatchClaims;
+        this.requiredClaims = requiredClaims;
+    }
+
+    @Override
+    public void verify(JWTClaimsSet claimsSet, SecurityContext context) throws BadJWTException {
+        if (expectedAudience != null) {
+            List<String> audience = claimsSet.getAudience();
+            if (audience == null || !audience.contains(expectedAudience)) {
+                throw new BadJWTException("JWT audience rejected: " + (audience != null ? audience : "[]"));
+            }
+        }
+
+        if (exactMatchClaims != null && !exactMatchClaims.getClaims().isEmpty()) {
+            for (Map.Entry<String, Object> entry : exactMatchClaims.getClaims().entrySet()) {
+                String claimName = entry.getKey();
+                Object expectedValue = entry.getValue();
+                Object actualValue = claimsSet.getClaim(claimName);
+                
+                if (!expectedValue.equals(actualValue)) {
+                    throw new BadJWTException("JWT " + claimName + " claim has value " + actualValue + ", must be " + expectedValue);
+                }
+            }
+        }
+
+        if (requiredClaims != null && !requiredClaims.isEmpty()) {
+            Set<String> missingClaims = new HashSet<>();
+            for (String requiredClaim : requiredClaims) {
+                if (claimsSet.getClaim(requiredClaim) == null) {
+                    missingClaims.add(requiredClaim);
+                }
+            }
+            if (!missingClaims.isEmpty()) {
+                List<String> sorted = new ArrayList<>(missingClaims);
+                sorted.sort(String::compareTo);
+                throw new BadJWTException("JWT missing required claims: " + sorted);
+            }
+        }
+
+        super.verify(claimsSet, context);
+    }
+}

--- a/mockserver-core/src/main/java/org/mockserver/authentication/jwt/JWTValidator.java
+++ b/mockserver-core/src/main/java/org/mockserver/authentication/jwt/JWTValidator.java
@@ -106,7 +106,7 @@ public class JWTValidator {
             if (this.matchingClaims != null) {
                 this.matchingClaims.forEach(matchingClaimsBuilder::claim);
             }
-            jwtProcessor.setJWTClaimsSetVerifier(new DefaultJWTClaimsVerifier<>(
+            jwtProcessor.setJWTClaimsSetVerifier(new CustomJWTClaimsVerifier(
                 this.expectedAudience,
                 matchingClaimsBuilder.build(),
                 this.requiredClaims

--- a/mockserver-netty/src/test/java/org/mockserver/clientandserver/ClientAndServerListenerTest.java
+++ b/mockserver-netty/src/test/java/org/mockserver/clientandserver/ClientAndServerListenerTest.java
@@ -5,6 +5,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.matchers.TimeToLive;
 import org.mockserver.matchers.Times;
 import org.mockserver.mock.Expectation;
+import org.mockserver.test.Retries;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,17 +35,19 @@ public class ClientAndServerListenerTest {
             );
 
         // then
-        assertThat(expectations.size(), is(1));
-        assertThat(expectations.get(0), is(new Expectation(
-            request()
-                .withPath("/some/path"),
-            Times.unlimited(),
-            TimeToLive.unlimited(),
-            0
-        ).thenRespond(
-            response()
-                .withBody("some_response_body")
-        )));
+        Retries.tryWaitForSuccess(() -> {
+            assertThat(expectations.size(), is(1));
+            assertThat(expectations.get(0), is(new Expectation(
+                request()
+                    .withPath("/some/path"),
+                Times.unlimited(),
+                TimeToLive.unlimited(),
+                0
+            ).thenRespond(
+                response()
+                    .withBody("some_response_body")
+            )));
+        });
     }
 
 }


### PR DESCRIPTION
## Summary

This PR fixes Java version compatibility issues and a flaky test that were causing PR build failures.

### Changes

1. **Block Java 17+ dependencies in Dependabot**
   - Added ignore rules for json-unit-core and json-path major version upgrades
   - Both libraries switched to Java 17 baseline in their 3.x releases
   - MockServer must remain Java 11 compatible

2. **Fix JWT validation error messages (PR #2005)**
   - Created CustomJWTClaimsVerifier to wrap Nimbus JWT exceptions
   - Provides informative, user-friendly error messages
   - Compatible with nimbus-jose-jwt 10.9 while maintaining stable error messages

3. **Fix flaky ClientAndServerListenerTest (PR #2006)**
   - Added Retries.tryWaitForSuccess() to handle async listener notifications
   - Listener notifications are executed via scheduler, not synchronously
   - Test now waits for async execution to complete before assertions

### Related Issues

- Closes #2015 (json-unit-core 5.1.1 - requires Java 17)
- Closes #2014 (json-path 3.0.0 - requires Java 17)  
- Fixes test failures in #2005 (nimbus-jose-jwt 10.9)
- Fixes test failures in #2006 (maven-gpg-plugin 3.2.8)

### Testing

- All JWT authentication tests pass
- ClientAndServerListenerTest passes consistently
- Changes maintain backward compatibility