### PR TITLE
test: validate native Buildkite trigger steps for PRs

### DIFF
--- a/docs/infrastructure/ci-cd.md
+++ b/docs/infrastructure/ci-cd.md
@@ -402,3 +402,5 @@ docker run -v $(pwd):/build/mockserver \
   mockserver/mockserver:maven \
   /build/mockserver/scripts/buildkite_quick_build.sh
 ```
+
+<!-- test: validate native Buildkite trigger steps work for PRs -->

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -1883,4 +1883,5 @@ public class ConfigurationProperties {
             return propertyValue;
         }
     }
+
 }


### PR DESCRIPTION
## Summary
- Validates that native Buildkite trigger steps work correctly for PR builds
- Tests PR env var forwarding (`BUILDKITE_PULL_REQUEST`, `BUILDKITE_PULL_REQUEST_BASE_BRANCH`)
- Touches both `mockserver/` and `docs/` to trigger Java + Infra child pipelines

## This PR will be closed after validation