### PR TITLE
build(deps): bump io.prometheus metrics libraries from 1.3.6 to 1.6.1

### DIFF
--- a/mockserver/pom.xml
+++ b/mockserver/pom.xml
@@ -595,17 +595,17 @@
             <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>prometheus-metrics-core</artifactId>
-                <version>1.3.6</version>
+                <version>1.6.1</version>
             </dependency>
             <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>prometheus-metrics-exposition-formats</artifactId>
-                <version>1.3.6</version>
+                <version>1.6.1</version>
             </dependency>
             <dependency>
                 <groupId>io.prometheus</groupId>
                 <artifactId>prometheus-metrics-model</artifactId>
-                <version>1.3.6</version>
+                <version>1.6.1</version>
             </dependency>
 
             <!-- spring -->


### PR DESCRIPTION
## Summary
- Bumps all three Prometheus client_java libraries together to 1.6.1 to avoid version conflicts
- `prometheus-metrics-core` 1.3.6 → 1.6.1
- `prometheus-metrics-exposition-formats` 1.3.6 → 1.6.1
- `prometheus-metrics-model` 1.3.6 → 1.6.1

## Compatibility
- Prometheus client_java targets Java 8, fully compatible with Java 11
- Replaces individual Dependabot PRs #2201, #2197, #2194, #2185 which each bumped only one library causing version conflicts