### PR TITLE
fix(core): preserve file response bodies during serialization

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed FILE-type response bodies being silently dropped during serialization. The `HttpResponseSerializer` and
+  `HttpResponseDTOSerializer` whitelist body types when writing the `body` field and had no branch for `FileBody`,
+  so a response configured with a file body was serialized without it (issue #2430). Both serializers now preserve
+  the file body, including its `filePath`, `contentType`, and `templateType`.
 - Fixed a broken build caused by a Maven dependency convergence error: `netty-tcnative-boringssl-static` was
   pinned to `2.0.77.Final` while the Netty `4.2.16.Final` upgrade pulled its native classifier artifacts in
   transitively at `2.0.78.Final`. Aligned the pinned version (and the matching `NETTY_TCNATIVE` Docker build

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializer.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializer.java
@@ -48,6 +48,8 @@ public class HttpResponseDTOSerializer extends StdSerializer<HttpResponseDTO> {
                 jgen.writeObjectField("body", body);
             } else if (body instanceof BinaryBodyDTO) {
                 jgen.writeObjectField("body", body);
+            } else if (body instanceof FileBodyDTO && ((FileBodyDTO) body).getFilePath() != null && !((FileBodyDTO) body).getFilePath().isEmpty()) {
+                jgen.writeObjectField("body", body);
             } else if (body instanceof LogEntryBodyDTO) {
                 jgen.writeObjectField("body", body);
             }

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseSerializer.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/serialization/serializers/response/HttpResponseSerializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.mockserver.model.*;
+import org.mockserver.serialization.model.FileBodyDTO;
 
 import java.io.IOException;
 
@@ -50,6 +51,8 @@ public class HttpResponseSerializer extends StdSerializer<HttpResponse> {
                 jgen.writeObjectField("body", body);
             } else if (body instanceof XmlBody && !((XmlBody) body).getValue().isEmpty()) {
                 jgen.writeObjectField("body", body);
+            } else if (body instanceof FileBody && ((FileBody) body).getFilePath() != null && !((FileBody) body).getFilePath().isEmpty()) {
+                jgen.writeObjectField("body", new FileBodyDTO((FileBody) body));
             } else if (body instanceof LogEntryBody) {
                 jgen.writeObjectField("body", body);
             }

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/serialization/HttpResponseSerializerTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/serialization/HttpResponseSerializerTest.java
@@ -11,8 +11,11 @@ import org.mockito.Mock;
 import org.mockserver.logging.MockServerLogger;
 import org.mockserver.model.Cookies;
 import org.mockserver.model.Delay;
+import org.mockserver.model.FileBody;
 import org.mockserver.model.Headers;
 import org.mockserver.model.HttpResponse;
+import org.mockserver.model.HttpTemplate;
+import org.mockserver.model.MediaType;
 import org.mockserver.serialization.model.BodyWithContentTypeDTO;
 import org.mockserver.serialization.model.DelayDTO;
 import org.mockserver.serialization.model.HttpResponseDTO;
@@ -149,6 +152,19 @@ public class HttpResponseSerializerTest {
         // then the inline schema survives the round trip
         assertThat(json.contains("\"generateFromSchema\""), is(true));
         assertThat(roundTripped.getGenerateFromSchema(), is("{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"}}}"));
+        assertThat(roundTripped, is(original));
+    }
+
+    @Test
+    public void shouldRoundTripFileBody() {
+        HttpResponseSerializer serializer = new HttpResponseSerializer(new MockServerLogger());
+        HttpResponse original = new HttpResponse()
+            .withStatusCode(200)
+            .withBody(new FileBody("/assets/file.xml", MediaType.APPLICATION_XML_UTF_8, HttpTemplate.TemplateType.MUSTACHE));
+
+        String json = serializer.serialize(original);
+        HttpResponse roundTripped = serializer.deserialize(json);
+
         assertThat(roundTripped, is(original));
     }
 

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializerTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseDTOSerializerTest.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import org.mockserver.model.Cookie;
 import org.mockserver.model.Delay;
+import org.mockserver.model.FileBody;
 import org.mockserver.model.Header;
+import org.mockserver.model.HttpTemplate;
+import org.mockserver.model.MediaType;
 import org.mockserver.serialization.ObjectMapperFactory;
 import org.mockserver.serialization.model.HttpResponseDTO;
 
@@ -103,6 +106,26 @@ public class HttpResponseDTOSerializerTest {
                 "  }," + NEW_LINE +
                 "  \"body\" : {" + NEW_LINE +
                 "    \"key\" : \"some_value\"" + NEW_LINE +
+                "  }" + NEW_LINE +
+                "}"));
+    }
+
+    @Test
+    public void shouldReturnFormattedResponseWithFileBody() throws JsonProcessingException {
+        assertThat(ObjectMapperFactory.createObjectMapper(true, false).writeValueAsString(
+            new HttpResponseDTO(
+                response()
+                    .withStatusCode(200)
+                    .withBody(new FileBody("/assets/file.xml", MediaType.APPLICATION_XML_UTF_8, HttpTemplate.TemplateType.MUSTACHE))
+            )
+            ),
+            is("{" + NEW_LINE +
+                "  \"statusCode\" : 200," + NEW_LINE +
+                "  \"body\" : {" + NEW_LINE +
+                "    \"contentType\" : \"application/xml; charset=utf-8\"," + NEW_LINE +
+                "    \"filePath\" : \"/assets/file.xml\"," + NEW_LINE +
+                "    \"templateType\" : \"MUSTACHE\"," + NEW_LINE +
+                "    \"type\" : \"FILE\"" + NEW_LINE +
                 "  }" + NEW_LINE +
                 "}"));
     }

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseSerializerTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/serialization/serializers/response/HttpResponseSerializerTest.java
@@ -5,7 +5,10 @@ import org.junit.Test;
 import org.mockserver.model.ConnectionOptions;
 import org.mockserver.model.Cookie;
 import org.mockserver.model.Delay;
+import org.mockserver.model.FileBody;
 import org.mockserver.model.Header;
+import org.mockserver.model.HttpTemplate;
+import org.mockserver.model.MediaType;
 import org.mockserver.serialization.ObjectMapperFactory;
 import org.mockserver.serialization.model.HttpResponseDTO;
 
@@ -95,6 +98,24 @@ public class HttpResponseSerializerTest {
                 "  }," + NEW_LINE +
                 "  \"body\" : {" + NEW_LINE +
                 "    \"key\" : \"some_value\"" + NEW_LINE +
+                "  }" + NEW_LINE +
+                "}"));
+    }
+
+    @Test
+    public void shouldReturnFormattedResponseWithFileBody() throws JsonProcessingException {
+        assertThat(ObjectMapperFactory.createObjectMapper(true, false).writeValueAsString(
+            response()
+                .withStatusCode(200)
+                .withBody(new FileBody("/assets/file.xml", MediaType.APPLICATION_XML_UTF_8, HttpTemplate.TemplateType.MUSTACHE))
+            ),
+            is("{" + NEW_LINE +
+                "  \"statusCode\" : 200," + NEW_LINE +
+                "  \"body\" : {" + NEW_LINE +
+                "    \"contentType\" : \"application/xml; charset=utf-8\"," + NEW_LINE +
+                "    \"filePath\" : \"/assets/file.xml\"," + NEW_LINE +
+                "    \"templateType\" : \"MUSTACHE\"," + NEW_LINE +
+                "    \"type\" : \"FILE\"" + NEW_LINE +
                 "  }" + NEW_LINE +
                 "}"));
     }


### PR DESCRIPTION
<!--
Thanks for contributing to MockServer! Please read CONTRIBUTING.md first:
https://github.com/mock-server/mockserver-monorepo/blob/master/CONTRIBUTING.md
Keep this PR focused on a single logical change.
-->

## What & why

- serialize `FileBody` values from both `HttpResponse` and `HttpResponseDTO`
- preserve `filePath`, `templateType`, and `contentType` when expectations are retrieved, exported, or logged
- add regression coverage for formatted serialization and round-trip behavior


The custom response serializers only handled the existing string, JSON, XML, binary, parameter, and log-entry body types. Although FILE bodies could be deserialized correctly, they were omitted when the response was serialized again.

Fixes #2430.

## Where

<!--
Which module(s) does this touch? See the "Where to make changes" table in
CONTRIBUTING.md to confirm the change is at the right architectural layer.
-->

- [x] `mockserver/mockserver-core`
- [ ] `mockserver/mockserver-netty`
- [ ] Client library (Java / Node / Python / Ruby)
- [ ] Dashboard UI (`mockserver-ui`)
- [ ] Build / CI / infrastructure
- [ ] Documentation only
- [ ] Other (describe above)

## Checklist

- [x] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and (for non-trivial changes) opened an issue first to discuss the approach.
- [x] The change is made at the architecturally correct layer (root cause, not the symptom).
- [ ] Tests added or updated for the new behaviour, and the relevant module's tests pass locally.
- [ ] User-facing changes have a `changelog.md` entry under `## [Unreleased]` (prefixed `BREAKING:` if applicable).
- [ ] User-facing changes update the consumer docs (`jekyll-www.mock-server.com/`) and/or internal docs (`docs/`) where relevant.
- [ ] Code targets **Java 17** (no APIs newer than Java 17; `jakarta.*` namespace where applicable).
- [ ] No secrets, credentials, or private endpoints are included in the diff.

## Notes for reviewers

<!-- Anything that helps review: trade-offs considered, areas you're unsure about, manual testing done. -->
