### PR TITLE
fix(testcontainers-python): read exposed ports through an int normaliser

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -244,7 +244,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `rate_limit_error` envelope with the exhausted rate-limit headers and `Retry-After`.
 
 ### Fixed
-- **BREAKING BEHAVIOUR: expectations persisted to a non-filesystem blob store are now saved under
+- **The `testcontainers-mockserver` (Python) port assertions no longer break against testcontainers
+  4.15.0, which keys `DockerContainer.ports` by `str(port)` rather than `int`.** `with_exposed_ports`
+  now stores `self.ports[str(port)] = None` (4.15.0 types the attribute as
+  `dict[str, Optional[int]]`), so the suite's `assert 1080 in container.ports` started failing with
+  `assert 1080 in {'1080': None}` and took five tests — and the whole `MockServer Python` pipeline,
+  and with it the umbrella `MockServer` build — red on `master`. The tests now read the exposed ports
+  through a normaliser that parses each key to an `int` (tolerating a `"1080/tcp"` protocol suffix),
+  so they assert the same thing under either key style. This also closes a latent false green: the
+  `assert MOCKSERVER_PORT not in container.ports` check in `test_replaces_default_port` passed
+  trivially once the keys became strings, and so would no longer have caught `with_server_port`
+  failing to drop the previously exposed port. Only the tests changed — `MockServerContainer` itself
+  was already correct, as `get_exposed_port` takes an `int` and normalises internally.
   `<blobStoreKeyPrefix>/<file name>` instead of under the writing machine's absolute local path, and a
   `blobStoreKeyPrefix` that does not end in a separator is now treated as a folder-style prefix instead
   of being glued straight onto the key (`mockserver` + `x.json` was `mockserverx.json` and is now

--- a/mockserver-testcontainers/python/tests/test_container_config.py
+++ b/mockserver-testcontainers/python/tests/test_container_config.py
@@ -10,6 +10,18 @@ from testcontainers_mockserver import MockServerContainer
 from testcontainers_mockserver.container import MOCKSERVER_PORT, _DEFAULT_TAG, _IMAGE_NAME
 
 
+def exposed_ports(container):
+    """Return the container's exposed ports as a set of ints.
+
+    testcontainers stores exposed ports keyed by ``str(port)`` (4.15.0 typed
+    ``ports`` as ``dict[str, Optional[int]]``), and the key may carry a protocol
+    suffix such as ``"1080/tcp"``. Normalising here keeps these assertions
+    meaningful across both key styles rather than silently passing whenever the
+    key type changes.
+    """
+    return {int(str(port).split("/")[0]) for port in container.ports}
+
+
 class TestDefaultConfiguration:
     """Tests for default container configuration (no Docker needed)."""
 
@@ -23,7 +35,7 @@ class TestDefaultConfiguration:
     def test_default_exposes_port_1080(self):
         container = MockServerContainer()
         # The ports dict keys are the container ports
-        assert MOCKSERVER_PORT in container.ports
+        assert MOCKSERVER_PORT in exposed_ports(container)
 
     def test_default_sets_server_port_env(self):
         container = MockServerContainer()
@@ -35,7 +47,7 @@ class TestDefaultConfiguration:
 
     def test_custom_port(self):
         container = MockServerContainer(port=9090)
-        assert 9090 in container.ports
+        assert 9090 in exposed_ports(container)
         assert container.env["SERVER_PORT"] == "9090"
 
 
@@ -48,15 +60,15 @@ class TestWithServerPort:
 
         assert result is container  # fluent return
         assert container.env["SERVER_PORT"] == "9090"
-        assert 9090 in container.ports
+        assert 9090 in exposed_ports(container)
 
     def test_replaces_default_port(self):
         container = MockServerContainer()
         container.with_server_port(9090)
 
         # Default port 1080 should no longer be exposed
-        assert MOCKSERVER_PORT not in container.ports
-        assert 9090 in container.ports
+        assert MOCKSERVER_PORT not in exposed_ports(container)
+        assert 9090 in exposed_ports(container)
 
 
 class TestWithLogLevel:
@@ -108,7 +120,7 @@ class TestFluentChaining:
         assert container.env["MOCKSERVER_LOG_LEVEL"] == "WARN"
         assert container.env["SERVER_PORT"] == "8080"
         assert container.env["MOCKSERVER_MAX_EXPECTATIONS"] == "100"
-        assert 8080 in container.ports
+        assert 8080 in exposed_ports(container)
 
 
 class TestUrlShaping:


### PR DESCRIPTION
## Why

`master` is red. The `MockServer Python` pipeline has failed on every build since #618, and because the umbrella `MockServer` pipeline triggers it, the umbrella build is red too (#6237–#6241 all failed for this single reason).

Root cause is an upstream contract change, not a MockServer regression: **testcontainers 4.15.0** keys `DockerContainer.ports` by `str(port)` rather than `int`.

```python
def with_exposed_ports(self, *ports: Union[str, int]) -> Self:
    for port in ports:
        self.ports[str(port)] = None   # <- stringified
    return self
```

and the attribute is now typed `dict[str, Optional[int]]`. The suite asserted `int` membership, so it started failing with:

```
AssertionError: assert 1080 in {'1080': None}
```

5 failed, 17 passed, 4 deselected.

## What changed

Tests only. Exposed ports are now read through a normaliser that parses each key to an `int` (tolerating a `"1080/tcp"` protocol suffix), so the assertions hold under either key style and the `testcontainers>=4.0.0` floor stays honest.

`MockServerContainer` itself was already correct and is **unchanged** — `get_exposed_port` takes an `int` and normalises internally, so the runtime path never broke.

## Latent false green also closed

After the keys became strings, this assertion in `test_replaces_default_port` passed *trivially*:

```python
assert MOCKSERVER_PORT not in container.ports   # 1080 not in {'1080': None} -> always True
```

It would no longer have caught `with_server_port` failing to drop the previously exposed port. Verified by degrading `with_server_port` to skip its `self.ports = {}` reset and confirming the test now fails:

```
assert 1080 not in {1080, 9090}
```

then restoring and re-running green.

## Verification

Run locally against testcontainers 4.15.0 with Docker Desktop 29.5.3 up:

- CI's exact command `pytest -m "not docker" -v` — **22 passed, 4 deselected** (was 5 failed, 17 passed)
- Docker-gated tests `pytest -m "docker"` — **4 passed** (these start a real MockServer container)
- Degrade-and-confirm-red as above, to prove the assertions still bite