### PR TITLE
fix(testcontainers-node): target the brace-expansion override so archiver.glob works

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **The cloud blob-store, async-broker and transparent-proxy CI steps no longer OOM-kill their own build
+- **`archiver.glob()` works again in `@mockserver/testcontainers` (Node), and CVE-2026-14257 stays
+  closed.** The previous remedy for the `brace-expansion` denial of service (GHSA-mh99-v99m-4gvg,
+  patched only in 5.0.8) was a blanket `"brace-expansion": "^5.0.8"` override. That resolved the whole
+  tree to a single hoisted 5.0.8 and `npm audit` reported zero vulnerabilities — but 5.x changed the
+  CommonJS export from a callable function to an object (`{ expand, EXPANSION_MAX, ... }`), while the
+  minimatch copies actually installed (3.1.5, 5.1.9, 9.0.9) all call it as `expand(pattern)`. Every
+  glob containing a brace therefore threw `TypeError: expand is not a function`, crashing
+  `archiver.glob()` — the path `testcontainers` uses to copy files into a container. The failure was
+  invisible because minimatch short-circuits patterns with no `{`, so plain globs kept working and the
+  unit suite stayed green. The override is now targeted: `readdir-glob` and `archiver-utils`' `glob`
+  take `minimatch@^10.2.5`, which depends on `brace-expansion@^5.0.5` and is written against the new
+  API, so both runtime copies land on the patched 5.0.8 with a matching minimatch. jest keeps its own
+  `minimatch@3.1.5` + `brace-expansion@1.1.16` pairing and is untouched. `npm audit --omit=dev` still
+  reports 0 vulnerabilities, and a new `dependency-integrity` unit test drives a brace pattern through
+  both runtime minimatch copies and through a real `archiver.glob()` tar, plus asserts expansion stays
+  bounded — it fails against the blanket override, so the silent half of this cannot return.
   before any test runs.** Each ran its Docker container with `--memory=4g`, but `mockserver/.mvn/jvm.config`
   pins the Maven JVM to `-Xmx6144m` and the wrapper prepends it to `MAVEN_OPTS`, so the `-am` dependency
   build was permitted a 6 GB heap inside a 4 GB cgroup and the kernel intermittently killed it with exit 137

--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CommonJS export from a callable function to an object (`{ expand, EXPANSION_MAX, ... }`), while the
   minimatch copies actually installed (3.1.5, 5.1.9, 9.0.9) all call it as `expand(pattern)`. Every
   glob containing a brace therefore threw `TypeError: expand is not a function`, crashing
-  `archiver.glob()` — the path `testcontainers` uses to copy files into a container. The failure was
+  `archiver.glob()`. The blast radius is narrower than it first looks — `testcontainers` copies files
+  with `archiver.directory()`/`.append()`, which pass no brace pattern and still work — so what broke
+  is brace globbing for anything in this module's runtime tree that does use it. The failure was
   invisible because minimatch short-circuits patterns with no `{`, so plain globs kept working and the
   unit suite stayed green. The override is now targeted: `readdir-glob` and `archiver-utils`' `glob`
   take `minimatch@^10.2.5`, which depends on `brace-expansion@^5.0.5` and is written against the new

--- a/mockserver-testcontainers/node/package-lock.json
+++ b/mockserver-testcontainers/node/package-lock.json
@@ -1456,15 +1456,15 @@
       }
     },
     "node_modules/archiver-utils/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2146,6 +2146,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4016,6 +4023,24 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -4545,15 +4570,18 @@
       }
     },
     "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/require-directory": {

--- a/mockserver-testcontainers/node/package.json
+++ b/mockserver-testcontainers/node/package.json
@@ -38,9 +38,16 @@
     "testcontainers": "^12.0.1"
   },
   "overrides": {
-    "brace-expansion": "^5.0.8",
     "js-yaml": "^4.2.0",
-    "protobufjs": "^7.6.3"
+    "protobufjs": "^7.6.3",
+    "readdir-glob": {
+      "minimatch": "^10.2.5"
+    },
+    "archiver-utils": {
+      "glob": {
+        "minimatch": "^10.2.5"
+      }
+    }
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/mockserver-testcontainers/node/tests/unit/dependency-integrity.test.ts
+++ b/mockserver-testcontainers/node/tests/unit/dependency-integrity.test.ts
@@ -1,0 +1,74 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Guards the dependency resolution this module pins through `overrides`.
+ *
+ * CVE-2026-14257 (GHSA-mh99-v99m-4gvg) is a denial of service in
+ * brace-expansion <= 5.0.7, patched only in 5.0.8. The obvious remedy — a blanket
+ * `"brace-expansion": "^5.0.8"` override — is WRONG here: 5.x changed the CommonJS
+ * export from a callable function to an object (`{ expand, EXPANSION_MAX, ... }`),
+ * while minimatch 3.x/5.x/9.x all call it as `expand(pattern)`. Forcing 5.0.8 under
+ * those minimatch versions makes every BRACE pattern throw
+ * "TypeError: expand is not a function", which crashes `archiver.glob()` — the path
+ * testcontainers uses to copy files into a container.
+ *
+ * That breakage is invisible to the rest of the suite because minimatch
+ * short-circuits patterns containing no "{", so plain globs keep working and
+ * `npm audit` reports a clean tree. These tests exercise a brace pattern
+ * specifically, so the silent half of that failure mode cannot come back.
+ */
+describe("dependency integrity (unit)", () => {
+  const bracePattern = "*.{txt,md}";
+
+  it("expands brace patterns through every runtime minimatch copy", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const archiverUtilsMinimatch = require("archiver-utils/node_modules/minimatch");
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const readdirGlobMinimatch = require("readdir-glob/node_modules/minimatch");
+
+    for (const [name, mod] of [
+      ["archiver-utils", archiverUtilsMinimatch],
+      ["readdir-glob", readdirGlobMinimatch],
+    ] as [string, { minimatch: (f: string, p: string) => boolean }][]) {
+      expect([name, mod.minimatch("c.md", bracePattern)]).toEqual([name, true]);
+      expect([name, mod.minimatch("a.txt", bracePattern)]).toEqual([name, true]);
+      expect([name, mod.minimatch("skip.bin", bracePattern)]).toEqual([name, false]);
+    }
+  });
+
+  it("bounds brace expansion so a pathological pattern cannot exhaust memory", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const braceExpansion = require("brace-expansion");
+    const expand: (p: string) => string[] =
+      typeof braceExpansion === "function" ? braceExpansion : braceExpansion.expand;
+
+    // 2^20 expansions if unbounded; the patched release caps the result instead.
+    const expanded = expand("{a,b}".repeat(20));
+    expect(expanded.length).toBeLessThan(2 ** 20);
+  });
+
+  it("archives files selected by a brace glob pattern", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const archiver = require("archiver");
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mockserver-archive-"));
+    for (const file of ["a.txt", "b.txt", "c.md", "skip.bin"]) {
+      fs.writeFileSync(path.join(dir, file), "contents");
+    }
+    const target = path.join(dir, "out.tar");
+
+    const bytesWritten = await new Promise<number>((resolve, reject) => {
+      const output = fs.createWriteStream(target);
+      const archive = archiver("tar");
+      archive.on("error", reject);
+      output.on("close", () => resolve(fs.statSync(target).size));
+      archive.pipe(output);
+      archive.glob(bracePattern, { cwd: dir });
+      archive.finalize().catch(reject);
+    });
+
+    expect(bytesWritten).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## The problem

`10c3ed70e` closed CVE-2026-14257 (GHSA-mh99-v99m-4gvg) with a blanket override:

```json
"overrides": { "brace-expansion": "^5.0.8" }
```

That does resolve the tree to a single hoisted 5.0.8 and `npm audit` reports zero vulnerabilities — but **it breaks brace globbing on `master` today**.

brace-expansion 5.x changed the CommonJS export from a callable function to an object:

```js
> require('brace-expansion')
{ EXPANSION_MAX: …, EXPANSION_MAX_LENGTH: …, expand: [Function] }   // not callable
```

The minimatch copies actually installed — **3.1.5, 5.1.9 and 9.0.9** — all call it as `expand(pattern)`. Verified against master's own lockfile:

```
minimatch9 plain  *.txt       -> true
minimatch9 BRACE  *.{txt,md}  -> BROKEN: TypeError: (0 , brace_expansion_1.default) is not a function
minimatch3 plain  *.txt       -> true
minimatch3 BRACE  *.{txt,md}  -> BROKEN: TypeError: expand is not a function
minimatch5 BRACE  *.{txt,md}  -> BROKEN: TypeError: expand is not a function
```

`archiver.glob('*.{txt,md}')` crashes outright on master:

```
TypeError: expand is not a function
    at braceExpand (node_modules/readdir-glob/node_modules/minimatch/minimatch.js:119:10)
    at new ReaddirGlob (node_modules/readdir-glob/index.js:133:32)
    at Archiver.glob (node_modules/archiver/lib/core.js:752:17)
```

### Blast radius (measured, not assumed)

Narrower than it first appears: `testcontainers` copies files with `archiver.directory()` and `.append()`, which pass no brace pattern — I confirmed `directory()` still produces a valid tar on master's tree. So the container file-copy path is **not** broken. What is broken is brace globbing anywhere in this module's runtime tree, including any direct `archiver.glob()` use.

It is still worth fixing: the override silently degrades a shared dependency's contract, and it is a live trap for the next caller that uses a `{a,b}` pattern.

### Why CI didn't catch it

minimatch short-circuits patterns containing no `{`, so plain globs keep working, `npm audit` stays clean, and the unit suite stays green. Only brace patterns fail — a silent, partial breakage.

## The fix

Target the override at the two runtime consumers instead, giving them a minimatch written against the new API:

```json
"readdir-glob":    { "minimatch": "^10.2.5" },
"archiver-utils":  { "glob": { "minimatch": "^10.2.5" } }
```

`minimatch@10.2.5` depends on `brace-expansion@^5.0.5`, so both runtime copies land on the patched **5.0.8 paired with a minimatch that can actually call it**. jest keeps its own `minimatch@3.1.5` + `brace-expansion@1.1.16` pairing, untouched.

Rejected alternatives, both empirically tested:
- `"archiver": "^8.0.0"` (archiver 8 pulls patched deps) — **archiver 8 is ESM-only** and testcontainers 12 is CJS, so the package fails to load: `SyntaxError: Cannot use import statement outside a module`.
- Overriding `minimatch` globally to 10 — breaks jest's `glob@7`, which requires the v3 callable export.

## Verification

- `npm ci`, `tsc` build, **16/16 unit**, **5/5 Docker integration** (real containers)
- `npm audit --omit=dev`: **0 vulnerabilities** (8 high before, all this advisory)
- DoS actually mitigated in the installed tree: `{a,b}`×20 expands to **100,000 (bounded)** vs **1,048,576 (unbounded)** on the vulnerable version
- `archiver.glob('*.{txt,md}')` produces a valid tar again

## Regression test

New `dependency-integrity` unit test drives a brace pattern through both runtime minimatch copies and a real `archiver.glob()` tar, and asserts expansion stays bounded. Confirmed it **fails against the blanket override** (`TypeError: expand is not a function`, 2 failures), so the silent half of this cannot come back.