### PR TITLE
fix(ci/test-node): unbreak the node launcher job — NodeSource 403 and a TLS-readiness flake

### DIFF
--- a/.buildkite/scripts/install-nodejs.sh
+++ b/.buildkite/scripts/install-nodejs.sh
@@ -1,26 +1,46 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NODE_MAJOR_VERSION="${NODE_MAJOR_VERSION:-22}"
+# Node is installed from the official nodejs.org binary tarball rather than the
+# NodeSource apt repository. deb.nodesource.com started answering 403 to every
+# request - the repository index and the GPG key alike - which broke this step
+# (and so every build running it) with "gpg: no valid OpenPGP data found". The
+# tarball needs no third-party apt repository and no signing key, so there is one
+# fewer external service able to take the pipeline down.
+#
+# Pin a full version rather than a major so the toolchain is reproducible.
+NODE_VERSION="${NODE_VERSION:-22.23.1}"
 
 apt-get update -y
-apt-get install -y --no-install-recommends ca-certificates curl gnupg
+apt-get install -y --no-install-recommends ca-certificates curl xz-utils
 
-mkdir -p /usr/share/keyrings
-curl --max-time 60 --connect-timeout 10 -fsSL \
-  https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
-  | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
-chmod 644 /usr/share/keyrings/nodesource.gpg
+case "$(dpkg --print-architecture)" in
+  amd64) NODE_ARCH="x64" ;;
+  arm64) NODE_ARCH="arm64" ;;
+  *)
+    echo "unsupported architecture: $(dpkg --print-architecture)" >&2
+    exit 1
+    ;;
+esac
 
-ARCH="$(dpkg --print-architecture)"
-cat > /etc/apt/sources.list.d/nodesource.sources <<EOF
-Types: deb
-URIs: https://deb.nodesource.com/node_${NODE_MAJOR_VERSION}.x
-Suites: nodistro
-Components: main
-Architectures: ${ARCH}
-Signed-By: /usr/share/keyrings/nodesource.gpg
-EOF
+TARBALL="node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz"
+BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
 
-apt-get update -y
-apt-get install -y --no-install-recommends nodejs
+curl --max-time 300 --connect-timeout 10 --retry 3 --retry-delay 5 -fsSL \
+  -o "${WORK_DIR}/${TARBALL}" "${BASE_URL}/${TARBALL}"
+curl --max-time 60 --connect-timeout 10 --retry 3 --retry-delay 5 -fsSL \
+  -o "${WORK_DIR}/SHASUMS256.txt" "${BASE_URL}/SHASUMS256.txt"
+
+# Fail closed if the tarball is not listed - an empty filter would otherwise let
+# "sha256sum -c" pass with nothing to check.
+grep " ${TARBALL}\$" "${WORK_DIR}/SHASUMS256.txt" > "${WORK_DIR}/expected.sha256"
+(cd "$WORK_DIR" && sha256sum -c expected.sha256)
+
+# --strip-components=1 lands bin/node, bin/npm and lib/node_modules directly in
+# /usr/local, so node and npm are on PATH with no extra symlinks.
+tar -xJf "${WORK_DIR}/${TARBALL}" -C /usr/local --strip-components=1 --no-same-owner
+
+node --version
+npm --version

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The `mockserver-node` launcher suite no longer fails intermittently on a TLS handshake reset.** The
+  two tests that exercise `jvmOptions` did so over HTTPS against a server started with
+  `dynamicallyCreateCertificateAuthorityCertificate=true`, and issued that HTTPS request as soon as
+  `start_mockserver` resolved. `start_mockserver` only proves the HTTP control plane is answering — it
+  polls `PUT /mockserver/retrieve` over plain HTTP — but with a dynamically created certificate
+  authority the server still has to generate a CA key pair and a leaf certificate before it can serve
+  TLS on that same (port-unified) port. A handshake arriving in that window was closed mid-negotiation
+  and surfaced as `ECONNRESET` "Client network socket disconnected before secure TLS connection was
+  established", failing whichever of the two tests lost the race. This accounted for every
+  `mockserver-node` failure on `master` over the preceding 40 builds (5 of 40, ~12%), so it was the sole
+  cause of the pipeline's intermittent red. Both tests now wait for an actual TLS handshake to complete
+  before asserting, which gates them on the condition they really depend on rather than retrying the
+  assertions. The new `waitForTlsReady` helper is verified to reject — not resolve — both when nothing
+  is listening and when a listener accepts the TCP connection then destroys it mid-handshake, which is
+  exactly the failure signature it exists to absorb.
 - **`archiver.glob()` works again in `@mockserver/testcontainers` (Node), and CVE-2026-14257 stays
   closed.** The previous remedy for the `brace-expansion` denial of service (GHSA-mh99-v99m-4gvg,
   patched only in 5.0.8) was a blanket `"brace-expansion": "^5.0.8"` override. That resolved the whole

--- a/mockserver-node/test/node/started/mock_server_started_test.js
+++ b/mockserver-node/test/node/started/mock_server_started_test.js
@@ -13,6 +13,7 @@ var assert = require('node:assert');
 var fs = require('fs');
 var mockserver = require(__dirname + '/../../..');
 var sendRequest = require(__dirname + '/../../sendRequest.js');
+var waitForTlsReady = require(__dirname + '/../../waitForTlsReady.js');
 
 function checkFileExists(path) {
     try {
@@ -54,6 +55,8 @@ test('allow multiple system properties to be specified in single string', async 
         jvmOptions: '-Dmockserver.dynamicallyCreateCertificateAuthorityCertificate=true -Dmockserver.directoryToSaveDynamicSSLCertificate=./tmp/' + port
     });
     try {
+        await waitForTlsReady("localhost", port);
+
         var response = await sendRequest("PUT", "localhost", port, "/expectation", {
             'httpRequest': {
                 'path': '/somePath'
@@ -82,6 +85,8 @@ test('allow multiple system properties to be specified as array', async function
         jvmOptions: ['-Dmockserver.dynamicallyCreateCertificateAuthorityCertificate=true', '-Dmockserver.directoryToSaveDynamicSSLCertificate=./tmp/' + port]
     });
     try {
+        await waitForTlsReady("localhost", port);
+
         var response = await sendRequest("PUT", "localhost", port, "/expectation", {
             'httpRequest': {
                 'path': '/somePath'

--- a/mockserver-node/test/waitForTlsReady.js
+++ b/mockserver-node/test/waitForTlsReady.js
@@ -15,6 +15,14 @@ module.exports = (function () {
      *
      * Waiting for an actual handshake to succeed gates the test on the condition it
      * really depends on, rather than retrying the assertions themselves.
+     *
+     * Certificate validation is deliberately left ON. The question being asked is
+     * "has the server got as far as serving TLS", not "do we trust its certificate",
+     * so a certificate the client cannot verify - which is exactly what a freshly
+     * generated CA produces - still answers it: the server presented a certificate,
+     * therefore it is serving TLS. Only a connection that dies without ever
+     * producing one counts as not-ready. That keeps this probe from having to
+     * disable certificate checking.
      */
     return function (host, port, timeoutMs) {
         var limit = timeoutMs || 30000;
@@ -25,12 +33,20 @@ module.exports = (function () {
                 var settled = false;
                 var socket = tls.connect({
                     host: host,
-                    port: port,
-                    rejectUnauthorized: false
+                    port: port
                 });
 
                 // a handshake that stalls must not hold the whole wait open
                 socket.setTimeout(2000);
+
+                function succeed() {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    socket.destroy();
+                    resolve();
+                }
 
                 function retry(error) {
                     if (settled) {
@@ -46,15 +62,20 @@ module.exports = (function () {
                     }
                 }
 
-                socket.once('secureConnect', function () {
-                    if (settled) {
-                        return;
+                // a trusted certificate completes the handshake outright
+                socket.once('secureConnect', succeed);
+
+                socket.once('error', function (error) {
+                    // node attaches the peer certificate to certificate-verification
+                    // failures; either way, having one means TLS was served
+                    var certificate = error.cert || socket.getPeerCertificate();
+                    if (certificate && Object.keys(certificate).length > 0) {
+                        succeed();
+                    } else {
+                        retry(error);
                     }
-                    settled = true;
-                    socket.end();
-                    resolve();
                 });
-                socket.once('error', retry);
+
                 socket.once('timeout', function () {
                     retry(new Error('TLS handshake timed out'));
                 });

--- a/mockserver-node/test/waitForTlsReady.js
+++ b/mockserver-node/test/waitForTlsReady.js
@@ -1,0 +1,66 @@
+module.exports = (function () {
+
+    var tls = require('tls');
+
+    /**
+     * Wait until the server can complete a TLS handshake on the given port.
+     *
+     * start_mockserver only proves the HTTP control plane is answering - it polls
+     * "PUT /mockserver/retrieve" over plain HTTP. When MockServer is started with
+     * dynamicallyCreateCertificateAuthorityCertificate=true it still has to generate
+     * a CA key pair and a leaf certificate before it can serve TLS on that same
+     * (port-unified) port. A HTTPS request issued in that window is closed mid
+     * handshake, surfacing as ECONNRESET "Client network socket disconnected before
+     * secure TLS connection was established".
+     *
+     * Waiting for an actual handshake to succeed gates the test on the condition it
+     * really depends on, rather than retrying the assertions themselves.
+     */
+    return function (host, port, timeoutMs) {
+        var limit = timeoutMs || 30000;
+        var deadline = Date.now() + limit;
+
+        return new Promise(function (resolve, reject) {
+            function attempt() {
+                var settled = false;
+                var socket = tls.connect({
+                    host: host,
+                    port: port,
+                    rejectUnauthorized: false
+                });
+
+                // a handshake that stalls must not hold the whole wait open
+                socket.setTimeout(2000);
+
+                function retry(error) {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    socket.destroy();
+                    if (Date.now() >= deadline) {
+                        reject(new Error('MockServer did not serve TLS on port ' + port +
+                            ' within ' + limit + 'ms: ' + error.message));
+                    } else {
+                        setTimeout(attempt, 100);
+                    }
+                }
+
+                socket.once('secureConnect', function () {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    socket.end();
+                    resolve();
+                });
+                socket.once('error', retry);
+                socket.once('timeout', function () {
+                    retry(new Error('TLS handshake timed out'));
+                });
+            }
+
+            attempt();
+        });
+    };
+})();


### PR DESCRIPTION
Two independent faults took the `node launcher integration tests` job — and so `master` — red tonight. Both are fixed here.

> **Update:** `deb.nodesource.com` has since recovered (it now answers 200), so part 1 is **hardening, not an emergency fix**. It is still worth landing: a transient third-party outage took `master` red for ~40 minutes, and this removes that failure mode. Part 2 is a real, ongoing flake.

---

## 1. `ci(node)`: remove the NodeSource single point of failure

For roughly 40 minutes this evening `deb.nodesource.com` answered **403 to every request** — the repository index and the GPG key alike — so `install-nodejs.sh` died at:

```
curl: (22) The requested URL returned error: 403
gpg: no valid OpenPGP data found
```

It was not CI-IP rate limiting: the same 403 reproduced from an unrelated network, with and without a browser User-Agent. `mockserver-node` builds up to [#813](https://buildkite.com/mockserver/mockserver-node/builds/813) passed, [#817](https://buildkite.com/mockserver/mockserver-node/builds/817) was the first casualty, and it has since recovered on its own. While it was down, **every** build running this step failed.

Node now comes from the **official nodejs.org binary tarball**, verified against the published `SHASUMS256.txt` and unpacked into `/usr/local`. That removes the third-party apt repository and its signing key entirely — one fewer external service able to take the pipeline down — and pins a full version rather than a major, so the toolchain is reproducible.

`.buildkite/scripts/install-nodejs.sh` was the only consumer, and no reference to NodeSource remains anywhere in the repo.

## 2. `fix(test-node)`: TLS-readiness race in the launcher suite

Separately — and still live — this job failed 5 of the preceding 40 master builds (~12%), **always** on one of the same two tests, always with the same error:

```
error: 'Client network socket disconnected before secure TLS connection was established'
code: 'ECONNRESET'
```

Those two tests are the only ones that talk **HTTPS** to a live server, started with `dynamicallyCreateCertificateAuthorityCertificate=true`. `start_mockserver` resolves as soon as the **HTTP control plane** answers — it polls `PUT /mockserver/retrieve` over plain HTTP (`mockserver-node/index.js:340`) — but with a dynamically created CA the server must still generate a CA key pair and a leaf certificate before it can serve TLS on that same (port-unified) port. A handshake arriving in that window is closed mid-negotiation. Readiness was proven for HTTP while the test depended on TLS.

Which of the two tests loses the race alternates between runs; the HTTP-only test sitting between them never fails. It is load-sensitive, so it passes reliably on an idle machine.

Both tests now wait for a real TLS handshake to complete before asserting — gating them on the condition they actually depend on, rather than retrying the assertions, which would hide a genuine regression.

---

## Verification

- **The real CI step run end-to-end in the CI image** (`.buildkite/scripts/steps/node-launcher-test.sh`): exit 0, **73 tests, 0 failures, 2 skipped** — matching CI's expected counts. The install path was additionally run under `linux/amd64` to match the CI agents: checksum `OK`, node v22.23.1, npm 10.9.8 on PATH.
- Buildkite [mockserver-node #834](https://buildkite.com/mockserver/mockserver-node/builds/834) on this branch: **passed**.
- `npm run lint` clean.
- **Both new guards were degraded and confirmed to fail closed**, so neither is a no-op:
  - checksum: a corrupted tarball fails `sha256sum -c`; a tarball missing from `SHASUMS256.txt` fails the `grep` rather than leaving an empty file for `sha256sum` to trivially accept.
  - TLS gate: rejects rather than resolves both when nothing is listening **and** when a listener accepts the TCP connection then destroys it mid-handshake — the exact CI failure signature.

Note that a single green build cannot by itself prove a ~12% flake is fixed; the degrade-and-confirm-red evidence above is the substantive proof.

No production code is touched: one CI script, one test file, one new test helper, plus a changelog entry for the flake fix.