### PR TITLE
fix(test-ui): survive jsdom's unresolvable-calc length regression

### DIFF
--- a/mockserver-ui/src/test-setup.ts
+++ b/mockserver-ui/src/test-setup.ts
@@ -3,6 +3,62 @@ import { vi } from 'vitest';
 import { createElement } from 'react';
 import { ensureWebStorage } from './test-setup-storage';
 
+// jsdom 30.0.0 added "convert length values into pixels" to getComputedStyle().
+// Its length resolver reduces calc() with cssValues.resolveCalc and then does
+//
+//     const [, value] = FONT_SIZE_REGEXP.exec(resolvedSize);
+//
+// with no null check. A calc() mixing a percentage with a length - MUI's Dialog
+// uses max-width/max-height: calc(100% - 64px) - cannot be reduced to a single
+// length without layout, which jsdom has no notion of, so resolveCalc returns it
+// unchanged, the regex does not match, and destructuring null throws
+// "object null is not iterable". @testing-library calls getComputedStyle() on
+// every accessibility/role query, so this takes out any test that renders a
+// Dialog rather than anything font-related.
+//
+// jsdom's own caller already treats a non-numeric result as "leave the value
+// alone", so returning NaN restores the pre-30 behaviour exactly. The wrapper
+// only changes anything when the original throws, so it neutralises itself once
+// jsdom ships a fix - delete it then, along with this comment.
+type LengthResolver = ((...args: unknown[]) => unknown) & { patched?: boolean };
+
+async function guardJsdomCalcLengthResolution(): Promise<void> {
+  try {
+    // Imported by path rather than from node:module so this file stays free of
+    // node typings (the UI tsconfig covers src with DOM libs only).
+    const specifier = 'jsdom/lib/jsdom/living/css/helpers/font-sizes.js';
+    const imported = (await import(/* @vite-ignore */ specifier)) as {
+      default?: { resolveLengthInPixels?: LengthResolver };
+      resolveLengthInPixels?: LengthResolver;
+    };
+    // A CommonJS module reached through ESM exposes module.exports as .default;
+    // that is the same object jsdom itself calls through, so patching it takes
+    // effect for the live document.
+    const fontSizes = imported.default ?? imported;
+    const original = fontSizes.resolveLengthInPixels;
+    if (typeof original !== 'function' || original.patched) {
+      return;
+    }
+    const guarded: LengthResolver = function (this: unknown, ...args: unknown[]): unknown {
+      try {
+        return original.apply(this, args);
+      } catch (error) {
+        // Only the unguarded destructure above - anything else is a real fault.
+        if (error instanceof TypeError && error.message.includes('is not iterable')) {
+          return Number.NaN;
+        }
+        throw error;
+      }
+    };
+    guarded.patched = true;
+    fontSizes.resolveLengthInPixels = guarded;
+  } catch {
+    // jsdom's internals are not a public API; if the path moves there is
+    // nothing to guard and the suite should still run.
+  }
+}
+await guardJsdomCalcLengthResolution();
+
 // jsdom does not always expose localStorage/sessionStorage (origin- and
 // build-dependent). Guarantee a working Storage so suites that clear/read it in
 // beforeEach are deterministic regardless of node_modules/jsdom install state.


### PR DESCRIPTION
Unblocks #2474 (jsdom 29.1.1 → 30.0.0), which currently fails 169 tests across 12 files.

## Cause

jsdom 30.0.0 added "convert length values into pixels" to `getComputedStyle()`. The new resolver reduces `calc()` via `cssValues.resolveCalc` and then does:

```js
const [, value] = FONT_SIZE_REGEXP.exec(resolvedSize);
```

with no null check. A `calc()` mixing a percentage with a length cannot be reduced to a single length without layout, which jsdom has no notion of, so `resolveCalc` returns the value unchanged, the regex does not match, and destructuring `null` throws `object null is not iterable`.

I confirmed the exact trigger by instrumenting jsdom locally:

```
JSDOM-TRIGGER size="calc(100% - 64px)" resolved="calc(100% - 64px)"
```

That is MUI's `Dialog`, which sizes itself with `max-width`/`max-height: calc(100% - 64px)`. `@testing-library` calls `getComputedStyle()` on every accessibility/role query, so it takes out any test that renders a Dialog — which is why the failures were broad and why none of them assert anything font-related.

This is an upstream defect, not an intentional break: 30.0.0's only documented breaking change is the raised Node floor, and there is no open jsdom issue for it.

## Fix

Guard the resolver so an unresolvable length yields `NaN`. jsdom's own caller already treats a non-numeric result as "leave the value alone", so this restores the pre-30 behaviour exactly rather than inventing one.

It is deliberately self-limiting:

- it only changes anything when the original **throws**, so it neutralises itself once jsdom ships a fix (delete it then — the comment says so);
- it re-raises any `TypeError` that is not this one, so it cannot mask unrelated faults;
- it is reached by path import rather than `node:module`, keeping the file free of node typings that the UI tsconfig does not carry.

## Verification

Full suite run against **both** jsdom versions, since this lands before the bump:

| jsdom | Result |
|---|---|
| 29.1.1 (current) | 192 files, 3044 tests — all pass |
| 30.0.0 (the bump) | 192 files, 3044 tests — all pass |

Plus `npm run lint` (0 errors; 14 pre-existing warnings, unchanged) and `npm run build` (strict `tsc -b` + vite) clean.

The jsdom-30 run is itself the proof the guard is live: the patch is wrapped in a `try`/`catch`, so had the import silently failed, those 169 tests would simply have failed again.

## After this merges

Rebase #2474 and it should go green.
