### PR TITLE
fix(config): report a property file that cannot be read instead of ignoring it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grows new reachable classes.
 
 ### Fixed
+- **A property file that cannot be read is now reported instead of ignored in silence
+  ([#2358](https://github.com/mock-server/mockserver-monorepo/issues/2358)).** When a
+  `mockserver.propertyFile` an operator had explicitly configured could not be read, MockServer applied
+  none of its properties and said nothing about it — at any log level. The only symptom was that every
+  property in the file appeared to be at its default, which surfaces far downstream as unexplained
+  behaviour: in the reported case an unreadable (but present) mounted file meant `initializationJsonPath`
+  was never set, so no expectations loaded, no `loading JSON initialization file:` line appeared, and no
+  error was logged either. The message existed but was unreachable in practice — gated at DEBUG *and*
+  emitted during static initialisation, before any log level has been applied, so neither
+  `-Dmockserver.logLevel=DEBUG` nor a `-logLevel` argument could surface it. Such a file is now logged at
+  WARN, naming the path and the underlying reason verbatim; because `FileNotFoundException` covers "not
+  there" and "not allowed to read it" alike, that reason is usually the whole answer (`Permission denied`
+  in the reported case, typically SELinux labelling or a rootless/user-namespace UID mismatch). A property
+  file that is merely absent at its default location stays quiet, as does the Docker image's built-in
+  `-Dmockserver.propertyFile=/config/mockserver.properties`, which the entrypoint always passes and which
+  therefore expresses no intent — otherwise every container started without a mounted config would warn.
+  Inside the image, only `MOCKSERVER_PROPERTY_FILE` can express that intent, and it does.
 - **The `mockserver-node` launcher suite no longer fails intermittently on a TLS handshake reset.** The
   two tests that exercise `jvmOptions` did so over HTTPS against a server started with
   `dynamicallyCreateCertificateAuthorityCertificate=true`, and issued that HTTPS request as soon as

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -687,11 +687,79 @@ public class ConfigurationProperties {
         return slf4jOrJavaLoggerToSLF4JLevelMapping;
     }
 
+    /**
+     * The Docker image's entrypoint always passes this, so seeing it says nothing about whether an
+     * operator chose a property file - only an environment variable can override it there.
+     */
+    private static final String DOCKER_DEFAULT_PROPERTY_FILE = "/config/mockserver.properties";
+
     private static String propertyFile() {
-        if (isNotBlank(System.getProperty(MOCKSERVER_PROPERTY_FILE)) && System.getProperty(MOCKSERVER_PROPERTY_FILE).equals("/config/mockserver.properties")) {
+        if (isNotBlank(System.getProperty(MOCKSERVER_PROPERTY_FILE)) && System.getProperty(MOCKSERVER_PROPERTY_FILE).equals(DOCKER_DEFAULT_PROPERTY_FILE)) {
             return isBlank(System.getenv("MOCKSERVER_PROPERTY_FILE")) ? System.getProperty(MOCKSERVER_PROPERTY_FILE) : System.getenv("MOCKSERVER_PROPERTY_FILE");
         } else {
             return System.getProperty(MOCKSERVER_PROPERTY_FILE, isBlank(System.getenv("MOCKSERVER_PROPERTY_FILE")) ? "mockserver.properties" : System.getenv("MOCKSERVER_PROPERTY_FILE"));
+        }
+    }
+
+    /**
+     * True when the property file path came from the operator rather than from a default.
+     *
+     * <p>A default that is simply absent is the normal case for anyone configuring MockServer another
+     * way, so it stays quiet. A path someone deliberately set and that then cannot be read is always
+     * worth reporting - see {@link #logPropertyFileNotRead}.
+     *
+     * <p>The Docker entrypoint's {@value #DOCKER_DEFAULT_PROPERTY_FILE} does NOT count as deliberate,
+     * or every container started without a mounted config would warn on startup.
+     */
+    private static boolean propertyFileExplicitlyConfigured() {
+        return propertyFileExplicitlyConfigured(System.getProperty(MOCKSERVER_PROPERTY_FILE), System.getenv("MOCKSERVER_PROPERTY_FILE"));
+    }
+
+    /**
+     * Package-private so the decision can be tested across every combination without setting system
+     * properties or environment variables, which are global state and unsafe under parallel execution.
+     */
+    static boolean propertyFileExplicitlyConfigured(String systemProperty, String environmentVariable) {
+        if (isNotBlank(environmentVariable)) {
+            return true;
+        }
+        return isNotBlank(systemProperty) && !systemProperty.equals(DOCKER_DEFAULT_PROPERTY_FILE);
+    }
+
+    /**
+     * Report a property file that could not be read, at a level that matches how much the operator
+     * asked for it.
+     *
+     * <p>An explicitly configured file that cannot be read is logged at WARN and always logged: it is
+     * a silent misconfiguration whose only other symptom is that every property in it is missing, which
+     * surfaces far downstream as unexplained default behaviour (mock-server/mockserver-monorepo#2358 -
+     * an unreadable file meant {@code initializationJsonPath} was never set, so no expectations loaded
+     * and nothing at all was logged). It cannot rely on the configured log level, because the level is
+     * itself read from the file that just failed to load, and a {@code -logLevel} command line argument
+     * is applied later still.
+     *
+     * <p>Note {@link FileNotFoundException} covers "not there" and "not allowed to read it" alike, so
+     * the reason is included verbatim - that distinction is usually the whole answer.
+     */
+    private static void logPropertyFileNotRead(String description, FileNotFoundException exception) {
+        if (LoggerHolder.LOGGER == null) {
+            return;
+        }
+        if (propertyFileExplicitlyConfigured()) {
+            LoggerHolder.LOGGER.logEvent(
+                new LogEntry()
+                    .setType(SERVER_CONFIGURATION)
+                    .setAlwaysLog(true)
+                    .setLogLevel(Level.WARN)
+                    .setMessageFormat(description + " [" + propertyFile() + "] could not be read so none of its properties have been applied - " + exception.getMessage())
+            );
+        } else if (MockServerLogger.isEnabled(DEBUG)) {
+            LoggerHolder.LOGGER.logEvent(
+                new LogEntry()
+                    .setType(SERVER_CONFIGURATION)
+                    .setLogLevel(DEBUG)
+                    .setMessageFormat(description + " not found using path [" + propertyFile() + "]")
+            );
         }
     }
 
@@ -6240,14 +6308,7 @@ public class ConfigurationProperties {
                     try {
                         properties.load(new FileInputStream(propertyFile()));
                     } catch (FileNotFoundException e) {
-                        if (LoggerHolder.LOGGER != null && MockServerLogger.isEnabled(DEBUG)) {
-                            LoggerHolder.LOGGER.logEvent(
-                                new LogEntry()
-                                    .setType(SERVER_CONFIGURATION)
-                                    .setLogLevel(DEBUG)
-                                    .setMessageFormat("property file not found using path [" + propertyFile() + "]")
-                            );
-                        }
+                        logPropertyFileNotRead("property file", e);
                     } catch (IOException e) {
                         if (LoggerHolder.LOGGER != null) {
                             LoggerHolder.LOGGER.logEvent(
@@ -6300,14 +6361,7 @@ public class ConfigurationProperties {
                 try {
                     inputStream = new FileInputStream(propertyFile());
                 } catch (FileNotFoundException e) {
-                    if (LoggerHolder.LOGGER != null && MockServerLogger.isEnabled(DEBUG)) {
-                        LoggerHolder.LOGGER.logEvent(
-                            new LogEntry()
-                                .setType(SERVER_CONFIGURATION)
-                                .setLogLevel(DEBUG)
-                                .setMessageFormat("JSON property file not found using path [" + propertyFile() + "]")
-                        );
-                    }
+                    logPropertyFileNotRead("JSON property file", e);
                     return properties;
                 }
             }

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/configuration/PropertyFileExplicitlyConfiguredTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/configuration/PropertyFileExplicitlyConfiguredTest.java
@@ -1,0 +1,72 @@
+package org.mockserver.configuration;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockserver.configuration.ConfigurationProperties.propertyFileExplicitlyConfigured;
+
+/**
+ * Guards which property file failures are worth telling the operator about
+ * (<a href="https://github.com/mock-server/mockserver-monorepo/issues/2358">#2358</a>).
+ *
+ * <p>In that issue a mounted {@code mockserver.properties} existed but could not be read by the
+ * MockServer process. Because "cannot read the property file" was logged only at DEBUG - and emitted
+ * during static initialisation, before any log level had been applied - the server started silently with
+ * none of the file's properties. The only visible symptom was that {@code initializationJsonPath} was
+ * never set, so no expectations loaded, with nothing in the log to explain why.
+ *
+ * <p>A file the operator explicitly pointed at and that cannot be read is therefore reported at WARN. The
+ * trap is the Docker image, whose entrypoint <em>always</em> passes
+ * {@code -Dmockserver.propertyFile=/config/mockserver.properties}: treating that as an explicit choice
+ * would make every container started without a mounted config warn on startup, which would train users to
+ * ignore the very warning this adds. Only an environment variable can express intent there.
+ *
+ * <p>These call the pure overload so no system property or environment variable is touched - both are
+ * global state and would make this unsafe to run in parallel.
+ */
+public class PropertyFileExplicitlyConfiguredTest {
+
+    private static final String DOCKER_DEFAULT = "/config/mockserver.properties";
+
+    @Test
+    public void shouldNotBeExplicitWhenNothingIsSet() {
+        assertThat("no property file configured at all is the default, so silence is correct",
+            propertyFileExplicitlyConfigured(null, null), is(false));
+    }
+
+    @Test
+    public void shouldNotBeExplicitWhenOnlyTheDockerEntrypointDefaultIsSet() {
+        assertThat("the Docker entrypoint always passes this, so it expresses no operator intent",
+            propertyFileExplicitlyConfigured(DOCKER_DEFAULT, null), is(false));
+    }
+
+    @Test
+    public void shouldBeExplicitWhenSystemPropertyPointsSomewhereElse() {
+        assertThat("a path the operator chose should be reported when it cannot be read",
+            propertyFileExplicitlyConfigured("/mockserver/mockserver.properties", null), is(true));
+    }
+
+    @Test
+    public void shouldBeExplicitWhenEnvironmentVariableOverridesTheDockerDefault() {
+        // The documented way to redirect the property file inside the Docker image.
+        assertThat("an environment variable is the only way to express intent in the Docker image",
+            propertyFileExplicitlyConfigured(DOCKER_DEFAULT, "/mockserver/mockserver.properties"), is(true));
+    }
+
+    @Test
+    public void shouldBeExplicitWhenOnlyEnvironmentVariableIsSet() {
+        assertThat("an environment variable alone is an explicit choice",
+            propertyFileExplicitlyConfigured(null, "/mockserver/mockserver.properties"), is(true));
+    }
+
+    @Test
+    public void shouldIgnoreBlankValues() {
+        assertThat("a blank system property is not a choice",
+            propertyFileExplicitlyConfigured("   ", null), is(false));
+        assertThat("a blank environment variable is not a choice",
+            propertyFileExplicitlyConfigured(null, "   "), is(false));
+        assertThat("a blank environment variable must not promote the Docker default",
+            propertyFileExplicitlyConfigured(DOCKER_DEFAULT, ""), is(false));
+    }
+}


### PR DESCRIPTION
Fixes #2358.

## The problem

When a property file the operator explicitly configured cannot be read, MockServer applies none of its properties and says **nothing about it, at any log level**.

The only symptom is that every property in the file appears to sit at its default, which surfaces far downstream as unexplained behaviour. In #2358 a mounted `mockserver.properties` was present — the reporter confirmed it with `docker container cp` — but unreadable by the process. So `initializationJsonPath` was never set, no expectations loaded, no `loading JSON initialization file:` line appeared, and no error was logged either. There was nothing to point at the cause, and the issue ran for six weeks with the wrong diagnosis (a bind mount believed not to be delivering files).

The message already existed but was unreachable in practice:

```java
} catch (FileNotFoundException e) {
    if (LoggerHolder.LOGGER != null && MockServerLogger.isEnabled(DEBUG)) { ... }
}
```

It is gated at DEBUG **and** emitted during static initialisation, before any log level has been applied — so neither `-Dmockserver.logLevel=DEBUG` nor a `-logLevel` argument can surface it. I confirmed that: a container pointed at a missing property file with DEBUG requested ran 147 log lines without ever mentioning it.

## The fix

Log it at **WARN**, naming the path and the underlying reason verbatim:

```
WARNING property file [/mockserver/mockserver.properties] could not be read so none of its
properties have been applied - /mockserver/mockserver.properties (Permission denied)
```

`FileNotFoundException` covers "not there" and "not allowed to read it" alike, and that distinction is usually the whole answer — `Permission denied` points straight at SELinux labelling or a rootless/user-namespace UID mismatch.

**Only for a file the operator actually chose.** A default that is simply absent stays quiet. So does the Docker image's built-in `-Dmockserver.propertyFile=/config/mockserver.properties`: the entrypoint *always* passes it, so it expresses no intent, and treating it as intent would warn on every container started without a mounted config — training users to ignore the very warning this adds. Inside the image only `MOCKSERVER_PROPERTY_FILE` can express that intent, which matches how `propertyFile()` already resolves it.

That decision is the regression-prone part, so it is exposed as a pure package-private overload and tested across every combination without touching system properties or environment variables — both global state, and unsafe under parallel execution.

## Verification

Real JVM, all four paths:

| `mockserver.propertyFile` | `MOCKSERVER_PROPERTY_FILE` | Expected | Result |
|---|---|---|---|
| `/definitely/not/here.properties` | — | WARN | WARN |
| `/config/mockserver.properties` (Docker default) | — | silent | silent |
| — | — | silent | silent |
| `/config/mockserver.properties` | `/mockserver/mockserver.properties` | WARN | WARN |

And against the actual #2358 shape — a file that exists but is unreadable:

```
WARNING property file [.../mockserver.properties] could not be read so none of its properties
have been applied - .../mockserver.properties (Permission denied)
```

with the same file made readable loading normally and warning nothing.

Tests: 355 `org.mockserver.configuration.*Test` pass, including the 6 new ones. The new test was checked by degrading the source — removing the Docker-default exclusion — which fails exactly the two cases that assert silence, so it is not a test that passes regardless.

## Not fixed here

This does not explain *why* the reporter's file was unreadable — that is environmental (their exact command and files work on 7.3.0; I reproduced it serving `200`). It makes the cause self-evident the moment it happens, which is what was missing.
