### PR TITLE
fix(test-node): give TLS readiness a budget that survives a loaded agent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -80,7 +80,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before asserting, which gates them on the condition they really depend on rather than retrying the
   assertions. The new `waitForTlsReady` helper is verified to reject — not resolve — both when nothing
   is listening and when a listener accepts the TCP connection then destroys it mid-handshake, which is
-  exactly the failure signature it exists to absorb.
+  exactly the failure signature it exists to absorb. The readiness budget is deliberately generous
+  (120s): waiting costs nothing when the server is healthy, since a ready server completes the
+  handshake on the first attempt in milliseconds, so the limit only decides how much CI contention is
+  tolerated before a slow start is misreported as a fault. An earlier 30s budget went green five builds
+  running and then expired on a loaded agent — the same flake wearing a clearer error message. A start
+  that takes over 5s is now reported even when it passes, because readiness creeping towards the limit
+  is the signal that the next run will not make it.
 - **`archiver.glob()` works again in `@mockserver/testcontainers` (Node), and CVE-2026-14257 stays
   closed.** The previous remedy for the `brace-expansion` denial of service (GHSA-mh99-v99m-4gvg,
   patched only in 5.0.8) was a blanket `"brace-expansion": "^5.0.8"` override. That resolved the whole

--- a/mockserver-node/test/waitForTlsReady.js
+++ b/mockserver-node/test/waitForTlsReady.js
@@ -25,12 +25,20 @@ module.exports = (function () {
      * disable certificate checking.
      */
     return function (host, port, timeoutMs) {
-        var limit = timeoutMs || 30000;
-        var deadline = Date.now() + limit;
+        // Generous on purpose. Waiting costs nothing when the server is healthy - a ready server
+        // completes the handshake on the first attempt in milliseconds - so the only thing this
+        // number decides is how much CI contention is tolerated before a slow start is called a
+        // failure. 30s was too tight: it went green five builds running and then failed on a loaded
+        // agent, which is the same flake in a new disguise rather than a real fault.
+        var limit = timeoutMs || 120000;
+        var start = Date.now();
+        var deadline = start + limit;
+        var attempts = 0;
 
         return new Promise(function (resolve, reject) {
             function attempt() {
                 var settled = false;
+                attempts++;
                 var socket = tls.connect({
                     host: host,
                     port: port
@@ -45,6 +53,13 @@ module.exports = (function () {
                     }
                     settled = true;
                     socket.destroy();
+                    var elapsed = Date.now() - start;
+                    // Surface a slow start rather than hiding it in a passing test: the failure mode
+                    // this guard exists for is readiness creeping towards the limit, and a green run
+                    // that took 40s is the warning that the next one will not be.
+                    if (elapsed > 5000) {
+                        console.error('# TLS on port ' + port + ' took ' + elapsed + 'ms (' + attempts + ' attempts) to become ready');
+                    }
                     resolve();
                 }
 
@@ -55,8 +70,11 @@ module.exports = (function () {
                     settled = true;
                     socket.destroy();
                     if (Date.now() >= deadline) {
+                        // Report the attempt count as well - "one attempt that hung" and "hundreds
+                        // that were refused" are different faults and the message should say which.
                         reject(new Error('MockServer did not serve TLS on port ' + port +
-                            ' within ' + limit + 'ms: ' + error.message));
+                            ' within ' + limit + 'ms (' + attempts + ' attempts over ' +
+                            (Date.now() - start) + 'ms): ' + error.message));
                     } else {
                         setTimeout(attempt, 100);
                     }


### PR DESCRIPTION
The TLS-readiness gate I added for the launcher HTTPS tests used a **30s** budget. It went green five builds running and then expired on master build 6343:

```
not ok 71 - allow multiple system properties to be specified in single string
  error: 'MockServer did not serve TLS on port 1082 within 30000ms: Client network
          socket disconnected before secure TLS connection was established'
```

That is the same flake as before, wearing a clearer error message rather than actually being gone. Correcting the record: my earlier "fixed" call rested on five consecutive green builds, which was not enough evidence for a fault that used to appear ~12% of the time.

The gate itself is right — it converted a confusing mid-assertion `ECONNRESET` into an explicit statement about readiness, which is the only reason the cause was identifiable. Only the limit was wrong, and it was a guess rather than a measured bound.

## Fix

Raise it to **120s**, and make slow starts visible:

- Waiting costs nothing when the server is healthy — a ready server completes the handshake on the first attempt in milliseconds — so this number only decides how much CI contention is tolerated before a slow start is misreported as a fault. Generous is free; tight is a flake.
- A readiness that takes **over 5s is now reported even when it passes**. Readiness creeping toward the limit is the signal the next run will not make it, and that was previously invisible.
- Failures now include **attempt count and elapsed time** — "one attempt that hung" and "hundreds that were refused" are different faults, and the message should say which.

## Ruled out first

So this is not another guess:

| Hypothesis | Verdict |
|---|---|
| The property file change on the same commit | **No** — the launcher never sets `-Dmockserver.propertyFile`, so that code path is unchanged for these tests. Build 850 passing on the previous commit and 851 failing on mine is coincidence. |
| Stale dynamically generated CA files in the gitignored `mockserver-node/tmp`, surviving across builds on a reused agent checkout | **No** — genuinely plausible (the directory persists, the agent checkout is bind-mounted into the container, nothing cleans it, and the CA is only generated when absent), but planting a truncated CA key showed the server regenerates and serves TLS normally. Disproven by experiment, not by argument. |

Retrying the job on the same commit passed, which is what a contention-bound slow start looks like and not what a deterministic fault looks like.

## Verification

The guard's own behaviour re-checked after the change: rejects when nothing is listening (with the new attempt data present), rejects when a listener accepts the TCP connection then destroys it mid-handshake, and the default budget is 120s. `npm run lint` — 9 files lint free.

The honest limit of this PR: it cannot *prove* the flake is gone, because the failure is contention-dependent and rare. What it does is remove the arbitrary 30s cliff and make a drift toward the limit observable before it turns red — so if this recurs, the log will say how close it was rather than leaving the next person to guess again.
