### PR TITLE
docs(security): stop naming a release the template sandbox may not ship in

### DIFF
--- a/jekyll-www.mock-server.com/mock_server/control_plane_authorisation.html
+++ b/jekyll-www.mock-server.com/mock_server/control_plane_authorisation.html
@@ -194,7 +194,7 @@ ConfigurationProperties.controlPlaneScopeMapping(Map.of(
 <a id="hardening_templates" class="anchor" href="#hardening_templates">&nbsp;</a>
 
 <h3>Response template execution</h3>
-<p>If you use <a href="/mock_server/response_templates.html">response templates</a>, note that since 7.4.1 templates cannot reach Java classes by default, so this hardening is already in place and nothing needs configuring (templates you do not use carry no risk):</p>
+<p>If you use <a href="/mock_server/response_templates.html">response templates</a>, note that templates cannot reach Java classes by default, so this hardening is already in place and nothing needs configuring (templates you do not use carry no risk):</p>
 <ul>
     <li><code class="inline_code">mockserver.velocityDisallowClassLoading</code> defaults to <code class="inline_code">true</code> &mdash; Velocity templates run with a secure uberspector so they cannot load arbitrary Java classes. Setting it to <code class="inline_code">false</code> re-opens that, which on an exposed control plane is a remote-code-execution path.</li>
     <li><code class="inline_code">mockserver.javascriptAllowedClasses</code> defaults to empty, meaning JavaScript templates resolve NO Java class via <code class="inline_code">Java.type(...)</code>. Only list classes a template genuinely needs, and avoid the <code class="inline_code">*</code> wildcard (fully unrestricted) on any instance untrusted callers can reach.</li>

--- a/jekyll-www.mock-server.com/mock_server/response_templates.html
+++ b/jekyll-www.mock-server.com/mock_server/response_templates.html
@@ -2442,7 +2442,7 @@ return {
 
 <p>Response templates execute code. A template that can reach classes such as <code class="inline code">java.lang.Runtime</code> or <code class="inline code">java.lang.ProcessBuilder</code> can run OS commands inside the MockServer process, so anyone able to register an expectation could run code on the machine MockServer is running on.</p>
 
-<p><strong>Since 7.4.1 templates cannot reach Java classes out of the box</strong>, so this is safe by default and you do not need to configure anything:</p>
+<p><strong>Templates cannot reach Java classes out of the box</strong>, so this is safe by default and you do not need to configure anything:</p>
 
 <ul>
     <li><strong>Velocity</strong> &mdash; <code class="inline code">velocityDisallowClassLoading</code> now defaults to <code class="inline code">true</code>, so class loading from within a Velocity template (for example <code class="inline code">$request.class.classLoader.loadClass(...)</code>) is blocked.</li>

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/Configuration.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/Configuration.java
@@ -3149,7 +3149,7 @@ public class Configuration {
     /**
      * Set comma separate list of classes not allowed to be used by javascript templates
      * <p>
-     * The default is empty. Since 7.4.1 an empty value means NO class is resolvable (see
+     * The default is empty, and an empty value means NO class is resolvable (see
      * {@link #javascriptAllowedClasses(String)}), not "all allowed"; setting a deny-list widens that
      * default to "everything except these" and is not a security boundary. Prefer the allow-list.
      *
@@ -3172,9 +3172,9 @@ public class Configuration {
      * templates may resolve via {@code Java.type(...)}. When set it takes precedence over
      * {@code javascriptDisallowedClasses} and nothing outside the list can be resolved.
      * <p>
-     * The default is empty, which since 7.4.1 means NO class can be resolved by a JavaScript template.
+     * The default is empty, which means NO class can be resolved by a JavaScript template.
      * The single entry {@code *} switches class restrictions off, letting a template resolve any class as
-     * it could before 7.4.1 — that makes a reachable control plane an RCE path (GHSA-7pwj-xvc2-hfpc), so
+     * earlier versions allowed by default — that makes a reachable control plane an RCE path (GHSA-7pwj-xvc2-hfpc), so
      * use it only when every template comes from a source you fully trust.
      *
      * @param javascriptAllowedClasses comma separated list of classes / package prefixes templates may use

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java
@@ -3956,7 +3956,7 @@ public class ConfigurationProperties {
     /**
      * Set comma separate list of classes not allowed to be used by javascript templates
      * <p>
-     * The default is empty. Since 7.4.1 an empty value means NO class is resolvable (see
+     * The default is empty, and an empty value means NO class is resolvable (see
      * {@link #javascriptAllowedClasses(String)}), not "all allowed"; setting a deny-list widens that
      * default to "everything except these" and is not a security boundary — a deny-list cannot enumerate
      * every dangerous class, so denying {@code java.lang.Runtime} still leaves {@code java.lang.ProcessBuilder}
@@ -3981,10 +3981,10 @@ public class ConfigurationProperties {
      * enumerate every dangerous class, so denying {@code java.lang.Runtime} still leaves
      * {@code java.lang.ProcessBuilder} and {@code Class.forName} reach-through available.
      * <p>
-     * The default is empty, which since 7.4.1 means NO class can be resolved by a JavaScript template —
+     * The default is empty, which means NO class can be resolved by a JavaScript template —
      * templates render normally but cannot reach host classes at all. Grant only the classes your templates
      * legitimately need. The single entry {@code *} switches class restrictions off, letting a template
-     * resolve any class as it could before 7.4.1; that makes a reachable control plane an RCE path
+     * resolve any class, as earlier versions allowed by default; that makes a reachable control plane an RCE path
      * (GHSA-7pwj-xvc2-hfpc), so use it only when every template comes from a source you fully trust.
      *
      * @param javascriptAllowedClasses comma separated list of classes / package prefixes templates may use

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/templates/engine/javascript/JavaScriptTemplateEngine.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/templates/engine/javascript/JavaScriptTemplateEngine.java
@@ -31,7 +31,7 @@ public class JavaScriptTemplateEngine implements TemplateEngine {
 
     /**
      * The single {@code javascriptAllowedClasses} entry that switches class restrictions off, so a template
-     * may resolve ANY class via {@code Java.type(...)} as it could before 7.4.1. Note this does not reopen
+     * may resolve ANY class via {@code Java.type(...)}, as earlier versions allowed by default. Note this does not reopen
      * the {@code getClass().getClassLoader()} walk — {@code PolyglotRunner} denies the members of
      * {@code Class}/{@code ClassLoader} unconditionally, since nothing legitimate needs that route.
      */
@@ -145,14 +145,14 @@ public class JavaScriptTemplateEngine implements TemplateEngine {
      *   <li><strong>Allow-list</strong> ({@code javascriptAllowedClasses}) — when set, ONLY entries on the
      *       list resolve and everything else is refused. This is the only form that is safe by
      *       construction and is the recommended setting. The single entry {@code *} lets any class resolve,
-     *       as before 7.4.1.</li>
+     *       as earlier versions did.</li>
      *   <li><strong>Deny-list</strong> ({@code javascriptDisallowedClasses}) — when set (and no allow-list
      *       is), listed entries are refused and everything else resolves. Retained for backwards
      *       compatibility; it is NOT a security boundary (see below).</li>
      *   <li>Otherwise <strong>nothing resolves</strong> — the default. A JavaScript template that has not
      *       been granted a class cannot reach host classes at all, so it cannot reach
      *       {@code java.lang.Runtime}/{@code java.lang.ProcessBuilder} and execute OS commands in the
-     *       MockServer process. Before 7.4.1 the default was unrestricted, which made a reachable control
+     *       MockServer process. In earlier versions the default was unrestricted, which made a reachable control
      *       plane plus a JavaScript template an RCE path (GHSA-7pwj-xvc2-hfpc).</li>
      * </ol>
      *


### PR DESCRIPTION
The template sandbox change (#2465, GHSA-7pwj-xvc2-hfpc) documents itself as landing in **7.4.1**, matching the current `7.4.1-SNAPSHOT`. But its changelog entry is prefixed `BREAKING:`, which by the convention in `AGENTS.md` signals a **major** bump — so the same change is documented as both 7.4.1 and, implicitly, 8.0.0. At least one is wrong.

Which one is a release-preparation decision, not something these comments should be guessing at. And a wrong version in a *security* note is worse than no version: it tells an operator they are patched when they are not.

So drop the number and describe the behaviour relative to earlier versions instead — "the default is empty, which means NO class can be resolved" rather than "which since 7.4.1 means…". The changelog and the advisory carry the version once it is actually known, which is where it belongs.

11 occurrences across 5 files (3 Java, 2 Jekyll pages). Comments and prose only — no behaviour change, and `mockserver-core` compiles clean.

Found while correcting the advisory text, which now also documents that the Velocity path — not the reported JavaScript one — is the half that shipped enabled in every distribution.