### PR TITLE
fix(oidc): revoke every spelling of a token, not just the string presented

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1295,6 +1295,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   window (or, for opaque providers, resolves to a recorded unexpired token). Additionally:
   - **`/revoke` now actually revokes.** It previously returned `200` and did nothing, so a revoked token kept
     introspecting as active. Revoked tokens are now recorded and report `active: false` (RFC 7009).
+    Revocation matches every spelling of a token that verifies as it, not just the exact string presented
+    to `/revoke` (GHSA-x2rq-8p73-q36w). Nimbus decodes Base64URL leniently and verifies the signature from
+    the decoded bytes, so appending a character outside the alphabet — `=`, a newline, `!` — to the
+    signature segment produces a different string that is still the same signed token; keying revocation on
+    the exact string let such a spelling sail past the revocation list and keep working at `/userinfo`.
+    Both halves of the fix are covered: revoking a token rejects its alternate spellings, and revoking an
+    alternate spelling rejects the canonical token.
   - **Inactive responses no longer leak claims.** An inactive result now contains `{"active": false}` and
     nothing else; previously it still returned `sub`, `iss`, `aud`, `scope` and every configured additional
     claim (RFC 7662 §2.2).

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/oidc/OidcAuthorizationStore.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/oidc/OidcAuthorizationStore.java
@@ -361,12 +361,49 @@ public class OidcAuthorizationStore {
         // scenario, and an unbounded map is a worse risk on a data-plane-reachable endpoint. If a
         // suite ever does approach the cap, reset the mock between tests.
         trimToCap(revokedTokens);
-        revokedTokens.put(token, Boolean.TRUE);
+        revokedTokens.put(revocationKey(token), Boolean.TRUE);
     }
 
     /** Whether the token has been revoked via {@link #revokeToken(String)}. */
     public boolean isRevoked(String token) {
-        return token != null && revokedTokens.containsKey(token);
+        return token != null && revokedTokens.containsKey(revocationKey(token));
+    }
+
+    /**
+     * The key a token is revoked under: the token with every character outside the Base64URL alphabet
+     * removed, the dot separators aside.
+     *
+     * <p>Revocation used to key on the exact string submitted to {@code /revoke}, which let a revoked
+     * JWT keep working under a different spelling (GHSA-x2rq-8p73-q36w). Nimbus decodes Base64URL
+     * leniently and skips characters outside the alphabet, and the signature is verified from the
+     * <em>decoded</em> bytes — so appending {@code =}, {@code \n}, {@code !} or {@code *} to the
+     * signature segment produces a string that is not equal to the revoked one yet still verifies as
+     * the same signed token. Presenting that spelling at {@code /userinfo} missed the revocation set
+     * and was accepted, which makes "my application rejects a revoked token" pass while proving
+     * nothing — the exact failure mode this store exists to close.
+     *
+     * <p>Collapsing those spellings to one key closes it, because every spelling Nimbus accepts as a
+     * given token maps to the same key.
+     *
+     * <p>Opaque tokens are matched exactly elsewhere ({@link #opaqueTokens}), so this only widens what
+     * counts as revoked. Two distinct opaque tokens differing solely by characters outside the
+     * Base64URL alphabet would share a key and be revoked together; that is
+     * fail-<em>closed</em>, consistent with revocation being global rather than per-provider, and the
+     * tokens this provider mints cannot collide that way.
+     */
+    private static String revocationKey(String token) {
+        StringBuilder key = new StringBuilder(token.length());
+        for (int index = 0; index < token.length(); index++) {
+            char character = token.charAt(index);
+            if (character == '.'
+                || (character >= 'A' && character <= 'Z')
+                || (character >= 'a' && character <= 'z')
+                || (character >= '0' && character <= '9')
+                || character == '-' || character == '_') {
+                key.append(character);
+            }
+        }
+        return key.toString();
     }
 
     /** Number of revoked tokens currently retained (test visibility). */

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/oidc/OidcUserinfoCallbackTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/oidc/OidcUserinfoCallbackTest.java
@@ -128,6 +128,57 @@ public class OidcUserinfoCallbackTest {
         assertThat(userinfo("Bearer " + accessToken).getStatusCode(), is(401));
     }
 
+    /**
+     * Regression test for GHSA-x2rq-8p73-q36w.
+     *
+     * <p>Revocation used to key on the exact string submitted to {@code /revoke}. Nimbus decodes
+     * Base64URL leniently, skipping characters outside the alphabet, and verifies the signature from
+     * the decoded bytes — so each spelling below is a different string that still verifies as the same
+     * signed token. Presenting one after revoking the original missed the revocation set and was
+     * accepted, letting a revoked token keep working.
+     */
+    @Test
+    public void shouldRejectRevokedTokenPresentedUnderAnAlternateSpelling() {
+        // Characters Nimbus ignores when decoding the signature segment. Each yields a string that is
+        // NOT equal to the revoked token yet verifies as it.
+        String[] ignoredTrailingCharacters = {"=", "==", "\n", "!", "*"};
+
+        for (String ignored : ignoredTrailingCharacters) {
+            OidcAuthorizationStore.getInstance().reset();
+            String accessToken = accessTokenFrom(generateProvider(new OidcProviderConfiguration()));
+            String alternateSpelling = accessToken + ignored;
+
+            assertThat("precondition: the alternate spelling is a different string",
+                alternateSpelling.equals(accessToken), is(false));
+            assertThat("precondition: the alternate spelling is accepted before revocation, so this "
+                    + "test would fail for the right reason rather than because it is simply invalid",
+                userinfo("Bearer " + alternateSpelling).getStatusCode(), is(200));
+
+            new OidcRevocationCallback().handle(request()
+                .withMethod("POST").withPath("/revoke").withBody("token=" + accessToken));
+
+            assertThat("revoking the token must also revoke every spelling that verifies as it",
+                userinfo("Bearer " + alternateSpelling).getStatusCode(), is(401));
+        }
+    }
+
+    /**
+     * The mirror of the above: revoking an alternate spelling must revoke the canonical token too,
+     * otherwise the bypass simply runs in the other direction.
+     */
+    @Test
+    public void shouldRejectCanonicalTokenAfterRevokingAnAlternateSpelling() {
+        String accessToken = accessTokenFrom(generateProvider(new OidcProviderConfiguration()));
+
+        assertThat("precondition: the token works before revocation",
+            userinfo("Bearer " + accessToken).getStatusCode(), is(200));
+
+        new OidcRevocationCallback().handle(request()
+            .withMethod("POST").withPath("/revoke").withBody("token=" + accessToken + "="));
+
+        assertThat(userinfo("Bearer " + accessToken).getStatusCode(), is(401));
+    }
+
     @Test
     public void shouldRejectTokenFromADifferentProvider() {
         OidcProviderConfiguration foreignConfig = new OidcProviderConfiguration()


### PR DESCRIPTION
Fixes GHSA-x2rq-8p73-q36w (reported by @corbanvilla, @soh3e, @dderpym).

## The bug

Revocation keyed on the **exact string** submitted to `/revoke`, so a revoked JWT kept working under a different spelling.

Nimbus decodes Base64URL leniently — it skips characters outside the alphabet — and verifies the signature from the *decoded* bytes. So appending an ignored character to the signature segment produces a string that is not equal to the revoked one yet still verifies as the same signed token. `isRevoked` missed it, `verifyAccessToken` accepted it, and `/userinfo` served claims for a token the caller had already revoked.

I confirmed this against Nimbus directly before writing any fix:

```
original verifies: true
token+=  -> differs=true verifies=true
token+== -> differs=true verifies=true
token+\n -> differs=true verifies=true
token+!  -> differs=true verifies=true
token+*  -> differs=true verifies=true
```

That makes "my application rejects a revoked token" a test that passes while proving nothing — the exact failure mode `OidcAuthorizationStore` exists to close.

## The fix

Key revocation on the token with every character outside the Base64URL alphabet removed (dot separators aside), so every spelling Nimbus accepts as a given token maps to one key.

Opaque tokens are matched exactly elsewhere (`opaqueTokens`), so this only ever *widens* what counts as revoked. Two opaque tokens differing solely by ignored characters would share a key and be revoked together — fail-**closed**, and consistent with revocation already being global rather than per-provider, which the existing code documents as a deliberate choice.

## Tests

Covered in **both directions**, because a one-directional fix just moves the bypass:

- revoking a token rejects its alternate spellings (all five characters above)
- revoking an alternate spelling rejects the canonical token

Each asserts the alternate spelling is accepted **before** revocation, so the test cannot pass merely because the token was invalid for some unrelated reason.

Reverting the fix fails exactly these two and nothing else. All 142 `org.mockserver.oidc.*` tests pass.

> Note for reviewers running these locally: the OIDC classes mutate a singleton and are deliberately excluded from the parallel Surefire phase and listed in the sequential one. Running them with an ad-hoc `-Dtest='org.mockserver.oidc.*Test'` bypasses that partitioning and they will interfere with each other — on unmodified `master` too. Run them per class, or via the normal build.

## Exposure

**None shipped.** `/revoke` doing anything at all is itself unreleased, so no published version is affected — which is why this strengthens the existing changelog entry rather than claiming a fix for users who were never at risk, and why no CVE is warranted.
