### PR TITLE
fix(release): truncate GitHub release notes instead of failing the step

### DIFF
--- a/scripts/release/components/github.sh
+++ b/scripts/release/components/github.sh
@@ -32,8 +32,41 @@ fi
 NOTES_FILE="$REPO_ROOT/.tmp/changelog-extract.md"
 mkdir -p "$REPO_ROOT/.tmp"
 echo "$CHANGELOG_EXTRACT" > "$NOTES_FILE"
-log_info "Notes preview:"
-sed 's/^/    /' "$NOTES_FILE"
+
+# GitHub rejects a release body over 125,000 characters with
+# HTTP 422 "Validation Failed / body is too long", which fails this step outright.
+# That is not hypothetical: 7.5.0 accumulated 245,801 characters of changelog over
+# 25 days and build #69 died here AFTER Maven Central, Docker, npm, PyPI and
+# RubyGems had already published - the worst possible place to stop, since the
+# release is public by then but has no GitHub Release.
+#
+# Truncate rather than fail. A release body is a convenience copy; changelog.md is
+# the source of truth, so pointing at it loses nothing. Leave headroom under the
+# limit for the pointer appended below.
+NOTES_LIMIT=120000
+NOTES_SIZE=$(wc -c < "$NOTES_FILE")
+if [[ "$NOTES_SIZE" -gt "$NOTES_LIMIT" ]]; then
+  log_info "Release notes are $NOTES_SIZE characters, over GitHub's 125,000 limit — truncating"
+  TRUNCATED_FILE="$REPO_ROOT/.tmp/changelog-extract-truncated.md"
+  # Cut on a line boundary (drop the partial final line) so the markdown does not
+  # end mid-construct - a body ending inside a table or code fence renders badly.
+  head -c "$NOTES_LIMIT" "$NOTES_FILE" | sed '$d' > "$TRUNCATED_FILE"
+  cat >> "$TRUNCATED_FILE" <<EOF
+
+---
+
+**These release notes are truncated.** This release's changelog entry exceeds GitHub's 125,000 character
+limit for a release body. Read the complete entry in
+[changelog.md](https://github.com/mock-server/mockserver-monorepo/blob/mockserver-$RELEASE_VERSION/changelog.md).
+EOF
+  mv "$TRUNCATED_FILE" "$NOTES_FILE"
+  log_info "  truncated to $(wc -c < "$NOTES_FILE") characters"
+fi
+
+# Preview a head only. Echoing the whole body made the job log almost entirely
+# release notes (2,653 lines for 7.5.0), which buried the actual failure.
+log_info "Notes preview (first 40 lines of $(wc -l < "$NOTES_FILE")):"
+head -40 "$NOTES_FILE" | sed 's/^/    /'
 
 if is_dry_run; then
   log_dry "skip: gh release create mockserver-$RELEASE_VERSION"


### PR DESCRIPTION
Release build #69 (7.5.0) failed at the GitHub Release step:

```
HTTP 422: Validation Failed (https://api.github.com/repos/mock-server/mockserver-monorepo/releases)
body is too long (maximum is 125000 characters)
```

## Why it matters more than a failed step

The step passed the entire changelog section through as the release body with no length guard. 7.5.0 accumulated **245,801 characters** over 25 days — nearly double GitHub's limit.

It failed **after** Maven Central, Docker, npm, PyPI and RubyGems had already published. That is the worst possible place to stop: the release is public and irreversible by then, but has no GitHub Release — and unlike a transient failure, retrying could never fix it, because the body would be too long every time.

## Fix

Truncate instead of failing. The release body is a convenience copy; `changelog.md` is the source of truth, so a body ending in a pointer to the full entry loses nothing:

- cut on a **line boundary** (drop the partial final line) so the markdown does not end mid-table or mid-code-fence
- leave headroom under the 125,000 limit for the appended pointer
- append a link to `changelog.md` at the release tag

Also **preview only the first 40 lines**. Echoing the whole body made the job log almost entirely release notes — 2,653 lines for 7.5.0 — burying the single line that said what went wrong. That cost real time during the incident.

## Verification

| Input | Result |
|---|---|
| Real 7.5.0 entry, 245,801 chars | → 120,262 chars, **under** the limit, ends cleanly |
| Real 7.3.0 entry, 42,765 chars | untouched — does not enter the truncation branch |

Plus `bash -n` clean.

## The 7.5.0 release is already whole

I completed it out-of-band rather than leaving a published release with no GitHub Release: created [mockserver-7.5.0](https://github.com/mock-server/mockserver-monorepo/releases/tag/mockserver-7.5.0) with these exact truncated notes, then retried the failed step, which went green through its existing `already exists` idempotency path. Build #69 is back to 0 failed.

This PR makes sure the next large release doesn't hit it at all.
