### PR TITLE
fix(vscode): match @types/vscode to the engine, and package in CI

### DIFF
--- a/.buildkite/scripts/steps/vscode-test.sh
+++ b/.buildkite/scripts/steps/vscode-test.sh
@@ -13,8 +13,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # container owns those files) leaves the workspace cleanly removable. The npm cache
 # (--cache npm, mounted separately) is untouched, so re-install stays fast. The trap
 # runs whether the tests pass or fail.
+# `vsce package` runs here, not just at release time. It enforces rules tsc does not
+# — notably that @types/vscode is not newer than engines.vscode — so compiling and
+# testing green says nothing about whether the extension can actually be packaged.
+# Release build #69 found that out the hard way: a Dependabot bump to
+# @types/vscode ^1.125.0 against engines.vscode ^1.80.0 passed every PR, then failed
+# the VS Code publish mid-release, after Maven Central and the rest had shipped.
+# Packaging to /tmp keeps the .vsix out of the bind-mounted workspace, which the
+# agent cannot clean up under userns-remap (see the node_modules note above).
 exec "$SCRIPT_DIR/../run-in-docker.sh" \
   -i node:20 \
   -w /build/mockserver-vscode \
   --cache npm \
-  -- bash -c 'trap "rm -rf node_modules" EXIT; npm ci && npm run compile && npm test'
+  -- bash -c 'trap "rm -rf node_modules" EXIT; npm ci && npm run compile && npm test && npx vsce package --out /tmp/mockserver-vscode.vsix'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -80,6 +80,18 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # @types/vscode's MINOR version is the VS Code API level, so it is not a
+      # routine minor bump: vsce refuses to package an extension whose
+      # @types/vscode exceeds engines.vscode. Raising it is a deliberate decision
+      # to drop support for older VS Code, which belongs with an engines.vscode
+      # change, not a dependency sweep. Bumped 1.80.0 -> 1.125.0 inside the
+      # minor-and-patch group in #21d7ae412; compile stayed green because this is
+      # a vsce rule rather than a tsc one, and it surfaced only when the release
+      # packaged the extension, leaving 7.5.0 without a VS Code release.
+      # Ceiling matches engines.vscode ^1.80.0.
+      - dependency-name: "@types/vscode"
+        versions: [">=1.81.0"]
 
   - package-ecosystem: "pip"
     directory: "/mockserver-client-python"

--- a/mockserver-vscode/package-lock.json
+++ b/mockserver-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mockserver",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mockserver",
-      "version": "7.4.0",
+      "version": "7.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jsonc-parser": "^3.3.1",
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.2",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "~1.80.0",
         "@types/ws": "^8.18.1",
         "@vscode/vsce": "^3.0.0",
         "ovsx": "^1.0.2",
@@ -421,9 +421,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -441,9 +438,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -461,9 +455,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -481,9 +472,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,11 +894,10 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.125.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
-      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.80.0.tgz",
+      "integrity": "sha512-qK/CmOdS2o7ry3k6YqU4zD3R2AYlJfbwBoSbKpBoP+GpXNE+0NEgJOli4n0bm0diK5kfBnchgCEj4igQz/44Hg==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/mockserver-vscode/package.json
+++ b/mockserver-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mockserver",
   "displayName": "MockServer",
-  "description": "Author and validate expectation files, generate from OpenAPI, record live traffic, inspect requests and drift, open the in-editor dashboard, and manage a local MockServer Docker container — all without leaving VS Code.",
+  "description": "Author and validate expectation files, generate from OpenAPI, record live traffic, inspect requests and drift, open the in-editor dashboard, and manage a local MockServer Docker container \u2014 all without leaving VS Code.",
   "version": "7.5.0",
   "publisher": "mockserver",
   "license": "Apache-2.0",
@@ -360,7 +360,7 @@
         "mockserver.binaryPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Path to a locally-installed MockServer binary bundle for the **Start (binary, no Docker)** command — either the `bin/mockserver` launcher itself or the unpacked bundle directory. Leave empty to download and cache the bundle matching this extension's version on first use. Useful on corporate machines without Docker."
+          "markdownDescription": "Path to a locally-installed MockServer binary bundle for the **Start (binary, no Docker)** command \u2014 either the `bin/mockserver` launcher itself or the unpacked bundle directory. Leave empty to download and cache the bundle matching this extension's version on first use. Useful on corporate machines without Docker."
         },
         "mockserver.binaryVersion": {
           "type": "string",
@@ -382,7 +382,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.1.2",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "~1.80.0",
     "@types/ws": "^8.18.1",
     "@vscode/vsce": "^3.0.0",
     "ovsx": "^1.0.2",

--- a/scripts/release/components/vscode.sh
+++ b/scripts/release/components/vscode.sh
@@ -28,6 +28,15 @@ skip_unless_release_type "vscode" full,post-maven
 
 log_step "Publish VS Code extension $RELEASE_VERSION (dry-run=$DRY_RUN)"
 
+# Publish the code that was released, not the commit the build was created from.
+# Every other publishing component does this; vscode was the sole exception, so it
+# shipped whatever was on the build's commit with the version sed'd in, missing
+# anything the release's own Prepare / Update Version References commits added.
+# That also made the step unretryable: a fix landed on master could not be picked
+# up, which is exactly the position build #69 was left in when the
+# @types/vscode-vs-engines.vscode mismatch failed the publish.
+sync_to_origin_master
+
 COMPONENT_DIR="$REPO_ROOT/mockserver-vscode"
 PKG_JSON="$COMPONENT_DIR/package.json"
 


### PR DESCRIPTION
Release build #69 failed publishing the VS Code extension for 7.5.0:

```
ERROR @types/vscode ^1.125.0 greater than engines.vscode ^1.80.0.
      Either upgrade engines.vscode or use an older @types/vscode version
```

A Dependabot bump moved `@types/vscode` to `^1.125.0` while `engines.vscode` stayed at `^1.80.0`. `vsce` refuses to package that: an extension must be typed against the **oldest** VS Code API it claims to support, otherwise it can compile against APIs absent from versions it declares support for.

## Why `~1.80.0`, not `^1.80.0`

`^1.80.0` is not a fix — it still resolves to **1.125.0**. The declared range would satisfy vsce's check while the *installed* types stayed newer than the engine, which is the actual hazard. I only caught this because I checked what npm resolved rather than trusting the range. `~1.80.0` installs 1.80.x.

## The gap matters more than the bump

CI ran `npm ci && npm run compile && npm test`. This is a **vsce** rule, not a `tsc` rule — so compile was green throughout, and the first time anything packaged the extension was **mid-release**, after Maven Central, Docker, npm, PyPI and RubyGems had already published.

So `vsce package` now runs in CI too, failing on the PR that introduces such a bump. It packages to `/tmp` to keep the `.vsix` out of the bind-mounted workspace, which the agent cannot clean under userns-remap (same reason as the existing `node_modules` trap).

## Verification

Both directions, because a fix I can't see fail isn't verified:

| `@types/vscode` | `npm run compile` | `vsce package` |
|---|---|---|
| `^1.125.0` (the bad state) | **passes** — why CI missed it | **fails**, with exactly the release error |
| `~1.80.0` (this PR) | passes | **passes** |

Plus 173 extension tests passing.

## Still outstanding

**The VS Code extension was not published for 7.5.0.** Everything else in the release went out. Once this merges, that step needs re-running, or the extension published out-of-band — I'll confirm which, since the release runner's checkout behaviour decides whether a retry picks up this fix.
