### PR TITLE
docs(release): Homebrew is automated, not a manual follow-up step

### DIFF
--- a/.claude/commands/release-management.md
+++ b/.claude/commands/release-management.md
@@ -102,7 +102,11 @@ Return a concise release-preparation report with these sections:
 ### Manual Follow-up
 
 - List only the steps still outside the automated pipeline
-- Today this should normally be just Homebrew
+- **Homebrew is NOT one of them** — do not report it as manual. Both formulae publish
+  automatically: `Homebrew/homebrew-core` via BrewTestBot from the `*-brew-tar.tar` artifact
+  on Maven Central, and `mock-server/homebrew-tap` via the pipeline's own `homebrew` step.
+  See `docs/operations/release-process.md` §9 and §11.
+- In practice the only conditional item is SwaggerHub, whose step is `soft_fail: true`
 
 ## Notes
 

--- a/.opencode/skills/release-management/SKILL.md
+++ b/.opencode/skills/release-management/SKILL.md
@@ -110,8 +110,17 @@ Return a concise release-preparation report with these sections:
 
 Steps outside — or not guaranteed by — the automated pipeline:
 
-- **Homebrew** — always manual, after the GitHub Release is published:
-  `brew bump-formula-pr --strict --version=<release-version> mockserver`
+- **Homebrew** — **not** a manual step; do not report it as one. Both formulae publish
+  automatically and need no action:
+  - `Homebrew/homebrew-core` (`mockserver`, JAR-based) is bumped by **BrewTestBot** from the
+    `*-brew-tar.tar` artifact on Maven Central, typically within a few hours
+    (`docs/operations/release-process.md` §9).
+  - `mock-server/homebrew-tap` (self-contained bundle) is pushed by the pipeline's own
+    `homebrew` step (§11).
+
+  Only intervene if BrewTestBot has not opened a PR a day or two after release — §9 lists what
+  to check, and `brew bump-formula-pr --strict --version=<release-version> mockserver` is the
+  fallback for a broken bot, not the normal path.
 - **SwaggerHub** — the `swaggerhub` pipeline step is `soft_fail: true`, so a failure
   never blocks the release. Publishing via the SwaggerHub Registry API needs
   account / API-plan access the pipeline cannot guarantee — the write endpoint can

--- a/docs/operations/release-process.md
+++ b/docs/operations/release-process.md
@@ -105,7 +105,7 @@ Versioned Site and Update Version References run first (sequentially), then the 
 
 ### 9. Homebrew homebrew-core — fully automated, no action required
 
-The `mockserver` formula in `Homebrew/homebrew-core` is bumped automatically by **BrewTestBot** (Homebrew's own automation account). This is a JAR-based formula that depends on an OpenJDK installation. A separate, complementary Homebrew tap formula (`mock-server/tap/mockserver`) installs the self-contained bundle instead — it is handled by §12 below. The chain for homebrew-core:
+The `mockserver` formula in `Homebrew/homebrew-core` is bumped automatically by **BrewTestBot** (Homebrew's own automation account). This is a JAR-based formula that depends on an OpenJDK installation. A separate, complementary Homebrew tap formula (`mock-server/tap/mockserver`) installs the self-contained bundle instead — it is published by the pipeline's own `homebrew` step, listed in §11 below. The chain for homebrew-core:
 
 1. The Maven release publishes a `mockserver-netty-<version>-brew-tar.tar` artifact to Maven Central (built and signed by `maven-central.sh`'s `-P release` profile, same lifecycle as the regular jars).
 2. The Homebrew formula has a `livecheck` block pointing at Maven Search (`https://search.maven.org/remotecontent?filepath=org/mock-server/mockserver-netty/maven-metadata.xml`). BrewTestBot's scheduled livecheck picks up the new version, computes the URL + SHA256, and opens a PR against `Homebrew/homebrew-core`.


### PR DESCRIPTION
The release-management skill (and its mirrored `.claude` command) told the operator Homebrew was **"always manual"**, with a `brew bump-formula-pr` command to run after every release.

That is wrong, and it contradicted this repo's own authoritative doc. `docs/operations/release-process.md` §9 is literally titled *"Homebrew homebrew-core — fully automated, no action required"* and states *"No human action is required, and no MockServer-side script needs to invoke `brew`."*

Both formulae publish on their own:

| Formula | How it publishes |
|---|---|
| `Homebrew/homebrew-core` (`mockserver`, JAR-based) | **BrewTestBot** picks up the `*-brew-tar.tar` artifact from Maven Central via the formula's `livecheck`, usually within hours (§9) |
| `mock-server/homebrew-tap` (self-contained bundle) | the pipeline's **own `homebrew` step** — it ran and **passed** in release build #71 (§11) |

`brew bump-formula-pr` is still documented, but as the fallback for a broken bot rather than the normal path.

## Why it mattered

The skill is what the release-preparation report is generated from, so **every release told the operator to perform a manual step that does not exist** — and it did exactly that for 7.5.0, which is how this was spotted.

## Also fixed

A stale cross-reference in the same area: §9 pointed at *"§12 below"* for the tap formula, but §12 is "Announce (optional)". The tap is covered by §11 (Package-manager channels).

## Verification

- `scripts/validate_opencode_config.sh` — passes
- Swept `docs/`, `.opencode/`, `.claude/`, `packaging/` for any remaining "manual Homebrew" claim: none left

## Note for review

This touches `.opencode/skills/**` and `.claude/commands/**`, which `AGENTS.md` classifies as **gated-approval rather than autonomous** — so this needs your explicit sign-off before merge rather than landing on a green build alone.
