### PR TITLE
test(ui): drop the jsdom calc guard now jsdom has fixed it upstream

### DIFF
--- a/mockserver-ui/src/test-setup.ts
+++ b/mockserver-ui/src/test-setup.ts
@@ -3,61 +3,6 @@ import { vi } from 'vitest';
 import { createElement } from 'react';
 import { ensureWebStorage } from './test-setup-storage';
 
-// jsdom 30.0.0 added "convert length values into pixels" to getComputedStyle().
-// Its length resolver reduces calc() with cssValues.resolveCalc and then does
-//
-//     const [, value] = FONT_SIZE_REGEXP.exec(resolvedSize);
-//
-// with no null check. A calc() mixing a percentage with a length - MUI's Dialog
-// uses max-width/max-height: calc(100% - 64px) - cannot be reduced to a single
-// length without layout, which jsdom has no notion of, so resolveCalc returns it
-// unchanged, the regex does not match, and destructuring null throws
-// "object null is not iterable". @testing-library calls getComputedStyle() on
-// every accessibility/role query, so this takes out any test that renders a
-// Dialog rather than anything font-related.
-//
-// jsdom's own caller already treats a non-numeric result as "leave the value
-// alone", so returning NaN restores the pre-30 behaviour exactly. The wrapper
-// only changes anything when the original throws, so it neutralises itself once
-// jsdom ships a fix - delete it then, along with this comment.
-type LengthResolver = ((...args: unknown[]) => unknown) & { patched?: boolean };
-
-async function guardJsdomCalcLengthResolution(): Promise<void> {
-  try {
-    // Imported by path rather than from node:module so this file stays free of
-    // node typings (the UI tsconfig covers src with DOM libs only).
-    const specifier = 'jsdom/lib/jsdom/living/css/helpers/font-sizes.js';
-    const imported = (await import(/* @vite-ignore */ specifier)) as {
-      default?: { resolveLengthInPixels?: LengthResolver };
-      resolveLengthInPixels?: LengthResolver;
-    };
-    // A CommonJS module reached through ESM exposes module.exports as .default;
-    // that is the same object jsdom itself calls through, so patching it takes
-    // effect for the live document.
-    const fontSizes = imported.default ?? imported;
-    const original = fontSizes.resolveLengthInPixels;
-    if (typeof original !== 'function' || original.patched) {
-      return;
-    }
-    const guarded: LengthResolver = function (this: unknown, ...args: unknown[]): unknown {
-      try {
-        return original.apply(this, args);
-      } catch (error) {
-        // Only the unguarded destructure above - anything else is a real fault.
-        if (error instanceof TypeError && error.message.includes('is not iterable')) {
-          return Number.NaN;
-        }
-        throw error;
-      }
-    };
-    guarded.patched = true;
-    fontSizes.resolveLengthInPixels = guarded;
-  } catch {
-    // jsdom's internals are not a public API; if the path moves there is
-    // nothing to guard and the suite should still run.
-  }
-}
-await guardJsdomCalcLengthResolution();
 
 // jsdom does not always expose localStorage/sessionStorage (origin- and
 // build-dependent). Guarantee a working Storage so suites that clear/read it in


### PR DESCRIPTION
jsdom **30.0.1** guards the destructure that 30.0.0 left unchecked:

```js
const matchLength = LENGTH_REGEXP.exec(resolvedSize);
if (matchLength) { ... }
```

So `getComputedStyle` no longer throws `object null is not iterable` on a `calc()` it cannot reduce — MUI's Dialog `calc(100% - 64px)` being the one that took out 169 tests in #2474. The shim added in #2476 was written to disappear at exactly this point, and says so in its own comment.

It was **already inert**: it only ever changed behaviour when the original threw, so it has done nothing since 30.0.1 landed. Removing it keeps the setup file honest rather than leaving a permanent monkey-patch of a third-party internal that no longer applies — which would also silently mask a future regression in the same function.

## Sequencing

Deliberately after #2491 moved the lockfile to 30.0.1. Removing it while the lockfile still pinned 30.0.0 would have reinstated the failure — `^30.0.0` alone was not enough, since the lockfile is what `npm ci` installs.

## Verification

Guard removed, installing from the lockfile (jsdom 30.0.1 confirmed at runtime):

| Check | Result |
|---|---|
| `vitest run` | **192 files, 3044 tests — all pass** |
| `npm run lint` | 0 errors (14 pre-existing warnings, unchanged) |
| `npm run build` (strict `tsc -b` + vite) | clean |

Net: −55 lines.