### PR TITLE
fix(core): make JSON body matching independent of the json-unit provider

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   provider won (for example `org.json`, whether because Jackson was not visible to json-unit or because
   `json-unit.libraries` pinned it) every JSON match threw `Unsupported type class
   com.fasterxml.jackson.databind.node.ObjectNode` and **no JSON body ever matched**. MockServer now falls back to
-  giving json-unit the raw JSON text, which every provider can parse ([#2496](https://github.com/mock-server/mockserver-monorepo/issues/2496)).
+  giving json-unit the raw JSON text, which it parses with whichever provider it resolved to
+  ([#2496](https://github.com/mock-server/mockserver-monorepo/issues/2496)).
 - Match failures from the JSON body matcher now report why the match failed. When JSON matching threw, the log said
   only `exception while perform json match failed` and the exception was recorded solely at `TRACE`, so at the
   default log level there was no way to tell a malformed body from a missing class from a runtime error. The cause

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- JSON body matching no longer depends on which JSON provider [json-unit](https://github.com/lukas-krecan/JsonUnit)
+  resolves to. MockServer parses both documents with Jackson and hands json-unit the resulting nodes to avoid
+  re-parsing on every match, but json-unit picks its provider by asking each in turn whether it claims the value
+  and falling back to the last one registered — and only its Jackson provider claims a Jackson node. Where another
+  provider won (for example `org.json`, whether because Jackson was not visible to json-unit or because
+  `json-unit.libraries` pinned it) every JSON match threw `Unsupported type class
+  com.fasterxml.jackson.databind.node.ObjectNode` and **no JSON body ever matched**. MockServer now falls back to
+  giving json-unit the raw JSON text, which every provider can parse ([#2496](https://github.com/mock-server/mockserver-monorepo/issues/2496)).
+- Match failures from the JSON body matcher now report why the match failed. When JSON matching threw, the log said
+  only `exception while perform json match failed` and the exception was recorded solely at `TRACE`, so at the
+  default log level there was no way to tell a malformed body from a missing class from a runtime error. The cause
+  is now included in the reported difference, as it already was for the XML schema, JSON path and JSON-RPC matchers.
 
 ## [7.5.0] - 2026-07-29
 

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/matchers/JsonStringMatcher.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/matchers/JsonStringMatcher.java
@@ -135,6 +135,16 @@ public class JsonStringMatcher extends BodyMatcher<String> {
     }
 
     public boolean matches(final MatchDifference context, String matched) {
+        return matches(context, matched, JSON_UNIT_ACCEPTS_JACKSON_NODES);
+    }
+
+    /**
+     * Match with the choice of json-unit input made explicit, so that both the pre-parsed Jackson
+     * node path and the raw JSON text fallback can be exercised directly. Which one production uses
+     * is decided once per JVM by {@link #JSON_UNIT_ACCEPTS_JACKSON_NODES}, which a test cannot vary
+     * without forking a JVM.
+     */
+    boolean matches(final MatchDifference context, String matched, boolean useJacksonNodes) {
         boolean result = false;
 
         try {
@@ -147,7 +157,7 @@ public class JsonStringMatcher extends BodyMatcher<String> {
                 try {
                     Object expected;
                     Object actual;
-                    if (JSON_UNIT_ACCEPTS_JACKSON_NODES) {
+                    if (useJacksonNodes) {
                         if (matcherJsonNode == null) {
                             matcherJsonNode = ObjectMapperFactory.createObjectMapper().readTree(matcher);
                         }
@@ -163,7 +173,7 @@ public class JsonStringMatcher extends BodyMatcher<String> {
                         expected = matcherJsonNode;
                         actual = matchedNode;
                     } else {
-                        // hand json-unit the raw JSON text, which every provider parses for itself
+                        // hand json-unit the raw JSON text and let it parse with its own provider
                         expected = matcher;
                         actual = matched;
                     }

--- a/mockserver/mockserver-core/src/main/java/org/mockserver/matchers/JsonStringMatcher.java
+++ b/mockserver/mockserver-core/src/main/java/org/mockserver/matchers/JsonStringMatcher.java
@@ -28,9 +28,24 @@ import static org.mockserver.character.Character.NEW_LINE;
  * @author jamesdbloom
  */
 public class JsonStringMatcher extends BodyMatcher<String> {
-    private static final String[] EXCLUDED_FIELDS = {"mockServerLogger"};
+    // matcherJsonNode, baseConfiguration and baseConfigurationMatchers are lazily populated caches
+    // derived entirely from matcher/matchType/matchNumbersAsStrings, so — like the derived fields
+    // excluded by the sibling matchers (JsonPathMatcher's jsonPath, XmlSchemaMatcher's
+    // xmlSchemaValidator, MultipartMatcher's decoder) — they must not take part in equality: two
+    // matchers built from the same JSON are the same matcher whether or not either has matched yet.
+    private static final String[] EXCLUDED_FIELDS = {"mockServerLogger", "matcherJsonNode", "baseConfiguration", "baseConfigurationMatchers"};
     private static final ObjectWriter PRETTY_PRINTER = ObjectMapperFactory.createObjectMapper(true, false);
     private static final ThreadLocal<Object[]> BODY_PARSE_CACHE = ThreadLocal.withInitial(() -> new Object[2]);
+    // Parsing both documents here and handing json-unit the resulting Jackson nodes avoids
+    // re-parsing on every match, but it makes matching depend on which JSON provider json-unit
+    // resolves to: it chooses a NodeFactory by asking each in turn whether it claims the value and
+    // falls back to the last one registered, and only its Jackson2 factory claims a Jackson node.
+    // Where json-unit resolves to another provider — e.g. json.org, whether because Jackson is not
+    // visible to json-unit or because json-unit.libraries pins it — that factory rejects the node
+    // with "Unsupported type class com.fasterxml.jackson.databind.node.ObjectNode" and NO JSON body
+    // ever matches (#2496). Probe once at class load; where the nodes are not accepted, fall back
+    // to giving json-unit the raw JSON text, which every provider can parse.
+    private static final boolean JSON_UNIT_ACCEPTS_JACKSON_NODES = jsonUnitAcceptsJacksonNodes();
     private final MockServerLogger mockServerLogger;
     private final String matcher;
     private volatile JsonNode matcherJsonNode;
@@ -58,6 +73,20 @@ public class JsonStringMatcher extends BodyMatcher<String> {
         this.matchType = matchType;
         this.matchNumbersAsStrings = matchNumbersAsStrings;
         this.options = optionsFor(matchType);
+    }
+
+    /**
+     * Whether json-unit, as resolved on this classpath, accepts pre-parsed Jackson nodes. Probed
+     * once with a trivial document; json-unit fixes its provider selection at class load, so the
+     * answer cannot change for the life of the JVM.
+     */
+    private static boolean jsonUnitAcceptsJacksonNodes() {
+        try {
+            JsonNode probe = ObjectMapperFactory.createObjectMapper().readTree("{\"a\":1}");
+            return Diff.create(probe, probe, "", "", Configuration.empty()).similar();
+        } catch (Throwable throwable) {
+            return false;
+        }
     }
 
     private static EnumSet<Option> optionsFor(MatchType matchType) {
@@ -116,22 +145,32 @@ public class JsonStringMatcher extends BodyMatcher<String> {
                 final Configuration diffConfig = baseConfiguration().withDifferenceListener(diffListener);
 
                 try {
-                    if (matcherJsonNode == null) {
-                        matcherJsonNode = ObjectMapperFactory.createObjectMapper().readTree(matcher);
-                    }
-                    Object[] cache = BODY_PARSE_CACHE.get();
-                    JsonNode matchedNode;
-                    if (matched.equals(cache[0])) {
-                        matchedNode = (JsonNode) cache[1];
+                    Object expected;
+                    Object actual;
+                    if (JSON_UNIT_ACCEPTS_JACKSON_NODES) {
+                        if (matcherJsonNode == null) {
+                            matcherJsonNode = ObjectMapperFactory.createObjectMapper().readTree(matcher);
+                        }
+                        Object[] cache = BODY_PARSE_CACHE.get();
+                        JsonNode matchedNode;
+                        if (matched.equals(cache[0])) {
+                            matchedNode = (JsonNode) cache[1];
+                        } else {
+                            matchedNode = ObjectMapperFactory.createObjectMapper().readTree(matched);
+                            cache[0] = matched;
+                            cache[1] = matchedNode;
+                        }
+                        expected = matcherJsonNode;
+                        actual = matchedNode;
                     } else {
-                        matchedNode = ObjectMapperFactory.createObjectMapper().readTree(matched);
-                        cache[0] = matched;
-                        cache[1] = matchedNode;
+                        // hand json-unit the raw JSON text, which every provider parses for itself
+                        expected = matcher;
+                        actual = matched;
                     }
                     result = Diff
                         .create(
-                            matcherJsonNode,
-                            matchedNode,
+                            expected,
+                            actual,
                             "",
                             "",
                             diffConfig
@@ -139,7 +178,7 @@ public class JsonStringMatcher extends BodyMatcher<String> {
                         .similar();
                 } catch (Throwable throwable) {
                     if (context != null) {
-                        context.addDifference(mockServerLogger, throwable, "exception while perform json match failed expected:{}found:{}", this.matcher, matched);
+                        context.addDifference(mockServerLogger, throwable, "exception while perform json match failed expected:{}found:{}failed because:{}", this.matcher, matched, describe(throwable));
                     }
                 }
 
@@ -155,11 +194,25 @@ public class JsonStringMatcher extends BodyMatcher<String> {
             }
         } catch (Throwable throwable) {
             if (context != null) {
-                context.addDifference(mockServerLogger, throwable, "json match failed expected:{}found:{}failed because:{}", this.matcher, matched, throwable.getMessage());
+                context.addDifference(mockServerLogger, throwable, "json match failed expected:{}found:{}failed because:{}", this.matcher, matched, describe(throwable));
             }
         }
 
         return not != result;
+    }
+
+    /**
+     * Describe a throwable for the match-failure report. The exception type is always included
+     * because it is the part that identifies the failure: a JSON parse error, a missing json-unit
+     * class and a runtime error are indistinguishable from the message alone (and some, such as
+     * NullPointerException, may carry no message at all), which left users of the JSON matcher
+     * unable to tell why a match had failed.
+     */
+    private static String describe(Throwable throwable) {
+        String message = throwable.getMessage();
+        return StringUtils.isNotBlank(message)
+            ? throwable.getClass().getName() + ": " + message
+            : throwable.getClass().getName();
     }
 
     private static class Difference implements DifferenceListener {

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/matchers/JsonStringMatcherTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/matchers/JsonStringMatcherTest.java
@@ -1,5 +1,6 @@
 package org.mockserver.matchers;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -14,7 +15,9 @@ import java.util.Map;
 import static org.mockserver.character.Character.NEW_LINE;
 import static org.mockserver.matchers.NotMatcher.notMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
+import static org.mockserver.model.HttpRequest.request;
 
 /**
  * @author jamesdbloom
@@ -748,6 +751,40 @@ public class JsonStringMatcherTest {
             ConfigurationProperties.customJsonUnitMatchersClass(previous);
             CustomJsonUnitMatcherLoader.reset();
         }
+    }
+
+    @Test
+    public void shouldReportCauseWhenJsonMatchThrows() {
+        // given - a body that cannot be parsed as JSON makes the match throw rather than simply not match
+        MatchDifference context = new MatchDifference(true, request().withPath("/some/path"));
+        context.currentField(MatchDifference.Field.BODY);
+
+        // when
+        assertThat(new JsonStringMatcher(
+            new MockServerLogger(),
+            "{\"id\":\"abc\"}",
+            MatchType.ONLY_MATCHING_FIELDS
+        ).matches(context, "this is not json"), is(false));
+
+        // then - the reported difference names the exception, so the failure can be diagnosed
+        String differences = String.join(NEW_LINE, context.getDifferences(MatchDifference.Field.BODY));
+        assertThat(differences, containsString("exception while perform json match failed"));
+        assertThat(differences, containsString("failed because:"));
+        assertThat(differences, containsString(JsonParseException.class.getName()));
+    }
+
+    @Test
+    public void shouldNotIncludeLazilyPopulatedCachesInEquality() {
+        // given - two matchers built from the same JSON, only one of which has been used
+        JsonStringMatcher used = new JsonStringMatcher(new MockServerLogger(), "{\"id\":\"abc\"}", MatchType.ONLY_MATCHING_FIELDS);
+        JsonStringMatcher unused = new JsonStringMatcher(new MockServerLogger(), "{\"id\":\"abc\"}", MatchType.ONLY_MATCHING_FIELDS);
+
+        // when - matching populates the used matcher's lazy caches
+        assertThat(used.matches(null, "{\"id\":\"abc\"}"), is(true));
+
+        // then - having matched does not change what the matcher is
+        assertThat(used, is(unused));
+        assertThat(used.hashCode(), is(unused.hashCode()));
     }
 
     public static class LargerThanMatcherProvider implements CustomJsonUnitMatcherProvider {

--- a/mockserver/mockserver-core/src/test/java/org/mockserver/matchers/JsonStringMatcherTest.java
+++ b/mockserver/mockserver-core/src/test/java/org/mockserver/matchers/JsonStringMatcherTest.java
@@ -773,6 +773,61 @@ public class JsonStringMatcherTest {
         assertThat(differences, containsString(JsonParseException.class.getName()));
     }
 
+    /**
+     * The raw-JSON-text fallback taken where json-unit will not accept pre-parsed Jackson nodes.
+     * Production picks between the two once per JVM from a system property read at json-unit class
+     * load, which a test cannot vary without forking, so the choice is passed in explicitly here.
+     */
+    @Test
+    public void shouldMatchThroughRawJsonTextWhenJsonUnitRejectsJacksonNodes() {
+        // exactly the bodies from #2496
+        assertThat(new JsonStringMatcher(new MockServerLogger(), "{ \"id\":  \"abc\" }" + NEW_LINE, MatchType.ONLY_MATCHING_FIELDS)
+            .matches(null, "{ \"id\":  \"abc\" }" + NEW_LINE, false), is(true));
+
+        // only the specified fields have to match
+        assertThat(new JsonStringMatcher(new MockServerLogger(), "{\"id\":\"abc\"}", MatchType.ONLY_MATCHING_FIELDS)
+            .matches(null, "{\"id\":\"abc\",\"other\":{\"deep\":[1,2]}}", false), is(true));
+
+        // nested objects and arrays still compare
+        assertThat(new JsonStringMatcher(new MockServerLogger(), "{\"o\":{\"a\":[1,2,3]}}", MatchType.ONLY_MATCHING_FIELDS)
+            .matches(null, "{\"o\":{\"a\":[1,2,3]}}", false), is(true));
+
+        // and genuinely different documents still do not match
+        assertThat(new JsonStringMatcher(new MockServerLogger(), "{\"id\":\"abc\"}", MatchType.ONLY_MATCHING_FIELDS)
+            .matches(null, "{\"id\":\"xyz\"}", false), is(false));
+
+        // a body that is not JSON at all must not match
+        assertThat(new JsonStringMatcher(new MockServerLogger(), "{\"id\":\"abc\"}", MatchType.ONLY_MATCHING_FIELDS)
+            .matches(null, "this is not json", false), is(false));
+
+        // STRICT still rejects extra fields
+        assertThat(new JsonStringMatcher(new MockServerLogger(), "{\"id\":\"abc\"}", MatchType.STRICT)
+            .matches(null, "{\"id\":\"abc\",\"extra\":1}", false), is(false));
+    }
+
+    @Test
+    public void shouldMatchIdenticallyThroughEitherJsonUnitInput() {
+        // the fallback must not change what matches - only how the documents reach json-unit
+        String[][] cases = {
+            {"{\"id\":\"abc\"}", "{ \"id\":  \"abc\" }"},
+            {"{\"id\":\"abc\"}", "{\"id\":\"abc\",\"extra\":1}"},
+            {"{\"id\":\"abc\"}", "{\"id\":\"xyz\"}"},
+            {"{\"a\":[1,2,3]}", "{\"a\":[3,2,1]}"},
+            {"{\"a\":[1,2,3]}", "{\"a\":[1,2,4]}"},
+            {"{\"n\":1}", "{\"n\":1}"},
+            {"{\"o\":{\"p\":\"q\"}}", "{\"o\":{\"p\":\"q\",\"r\":\"s\"}}"},
+            {"{\"id\":\"abc\"}", "this is not json"},
+        };
+        for (String[] testCase : cases) {
+            JsonStringMatcher matcher = new JsonStringMatcher(new MockServerLogger(), testCase[0], MatchType.ONLY_MATCHING_FIELDS);
+            assertThat(
+                "same verdict either way for expected " + testCase[0] + " and actual " + testCase[1],
+                matcher.matches(null, testCase[1], false),
+                is(matcher.matches(null, testCase[1], true))
+            );
+        }
+    }
+
     @Test
     public void shouldNotIncludeLazilyPopulatedCachesInEquality() {
         // given - two matchers built from the same JSON, only one of which has been used


### PR DESCRIPTION
Investigates and fixes [#2496](https://github.com/mock-server/mockserver-monorepo/issues/2496).

## Summary

The reported symptom — JSON body matching never matching, with `exception while perform json match failed` in the log — does **not** reproduce on a stock 7.5.0 image. The reporter's exact setup (7.5.0 Docker image, `mockserver-client-java` 7.5.0, rest-assured/Apache HttpClient 4.5.13, the same text-block bodies including the trailing newline that gives their `Content-Length: 17`) matches with a 200, as do the `-aot` and `latest` image variants, ~20 fuzzed body shapes, and a concurrent 20-expectation stress run.

However, there **is** a real mechanism that produces that log verbatim, and a diagnosability gap that made it impossible to identify from the issue alone. Both are fixed here.

## Root cause

MockServer parses both documents with Jackson and hands json-unit the resulting nodes, so a repeated body is not re-parsed on every match (`37e0561b3`, `ab76a5b5e`). That makes matching depend on which JSON provider json-unit resolves to: `Converter.findBestFactory` asks each `NodeFactory` in turn whether it claims the value and **falls back to the last one registered**, and only the Jackson provider claims a Jackson node.

Where another provider wins, it rejects the node and *every* JSON match throws — no JSON body ever matches:

```
java.lang.IllegalArgumentException: Unsupported type class com.fasterxml.jackson.databind.node.ObjectNode
    at net.javacrumbs.jsonunit.core.internal.JsonOrgNodeFactory.newNode(JsonOrgNodeFactory.java:75)
```

Merely having `org.json` on the classpath is harmless — Jackson still wins. The break needs json-unit resolved to a non-Jackson provider: Jackson not visible to json-unit, or `json-unit.libraries` pinning another one.

## Changes

- **Provider independence.** Probe once whether json-unit accepts Jackson nodes; where it does not, hand it the raw JSON text, which every provider parses. The fast pre-parsed path is unchanged in the normal case.
- **Report the cause.** The difference said only `exception while perform json match failed`, and the throwable was recorded *solely* at `TRACE` — so at the default log level a malformed body, a missing class and a runtime error were indistinguishable. The cause is now included, as `XmlSchemaMatcher`, `JsonPathMatcher` and `JsonRpcMatcher` already do.
- **Equality hygiene.** Exclude the lazily populated caches (`matcherJsonNode`, `baseConfiguration`, `baseConfigurationMatchers`) from `equals`/`hashCode`, matching every sibling matcher, so whether a matcher has matched yet does not change what it equals.

## Verification

A/B against the failing configuration (`-Djson-unit.libraries=json.org`, real `org.json` on the classpath):

| | before | after |
|---|---|---|
| broken provider | `matches=false`, reporter's exact log signature | `matches=true` |
| default classpath | `matches=true` | `matches=true` (fast path) |

- `JsonStringMatcherTest`: 37 pass (35 existing + 2 new, covering the reported cause and the equality fix).
- Full `org.mockserver.matchers.**` package run: the only failures are in `MatchingLimitsInstanceConfigurationTest`, which fails identically on a pristine tree under the same command (3 vs 6 failures across runs — a pre-existing shared-global-counter flake from ad-hoc parallel `-Dtest` selection, unrelated to JSON).

## Open question for the reporter

Since their setup does not reproduce on a stock image, it is not yet confirmed that this was *their* cause. The issue asks them to re-run with `-Dmockserver.logLevel=TRACE` and post the exception, which this change now surfaces at the default level too.