### PR TITLE
build(deps): align spring-webflux with the rest of the build in examples

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -69,6 +69,14 @@
                 <version>${spring-web.version}</version>
             </dependency>
             <dependency>
+                <!-- Spring Boot manages spring-webflux below the version the rest of the build
+                     uses, which left it on a release covered by the July 2026 Spring Framework
+                     advisories -->
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webflux</artifactId>
+                <version>${spring-web.version}</version>
+            </dependency>
+            <dependency>
                 <!-- Conflicting versions in okhttp and okio (both from okhttp) -->
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib</artifactId>


### PR DESCRIPTION
Addresses the 20 open Dependabot alerts (5 high, 13 moderate, 2 low) from the July 2026 Spring Framework advisory batch.

## Assessment

**Nothing MockServer distributes was affected.** Every shipped module already resolves Spring **7.0.8**, which is the fixed version for all 20 CVEs. I verified this against the resolved dependency tree rather than the manifests.

Exactly one artifact in the whole reactor was on an affected version:

```
mockserver-examples
  \- spring-boot-starter-webflux:4.0.6
     \- spring-boot-webflux:4.0.6
        \- spring-webflux:7.0.7      <-- affected (>= 7.0.0, <= 7.0.7 -> 7.0.8)
```

`mockserver-examples` is in the reactor only "so they stay compiled/tested" and is not part of any published artifact, so this was never user-facing — but it is a genuine version-range hit and worth closing.

**Cause:** the build declares `spring.version` / `spring-web.version` as 7.0.8, but never declares `spring-webflux`, so Spring Boot 4.0.6's own dependency management won and pinned it to 7.0.7. The examples module already pins `spring-aop` and `spring-expression` to `${spring-web.version}` for precisely this Boot-versus-build conflict — `spring-webflux` was simply missed from that list. This adds it alongside them.

## A note on the alert metadata

The alerts are misleading and should not be read at face value. All 20 report the matched range as `<= 5.3.39` with `first_patched_version: null`, which reads as "you are on EOL Spring 5.3 and there is no fix". That is wrong — there is no Spring 5.x anywhere in this repo, and no pom references one. The advisories each carry four ranges, and the applicable one is:

```
>= 7.0.0, <= 7.0.7   -> 7.0.8      <-- the real match
>= 6.2.0, <= 6.2.18  -> 6.2.19
>= 6.1.0, <= 6.1.21  -> NONE
<= 5.3.39            -> NONE       <-- what the alerts report
```

Consequently the 15 alerts for `spring-webmvc`, `spring-expression` and `spring-core` appear to be false positives: those already resolve to 7.0.8. They may need dismissing by hand if Dependabot does not retire them on its next scan.

## Verification

- `spring-webflux` now resolves to `7.0.8`; no Spring artifact anywhere in the reactor is below 7.0.8.
- Enforcer `DependencyConvergence` passes for the examples module.
- `spring-webflux:7.0.8` confirmed to exist and download from Central.